### PR TITLE
Yongzhe pr

### DIFF
--- a/cinderx/Interpreter/3.14/Includes/ceval_macros.h
+++ b/cinderx/Interpreter/3.14/Includes/ceval_macros.h
@@ -280,10 +280,19 @@ GETITEM(PyObject *v, Py_ssize_t i) {
 #define ADAPTIVE_COUNTER_TRIGGERS(COUNTER) \
     backoff_counter_triggers(forge_backoff_counter((COUNTER)))
 
+#ifdef CINDER_ENABLE_STATIC_PYTHON
 #define ADVANCE_ADAPTIVE_COUNTER(COUNTER) \
-    if (adaptive_enabled) { \
+    do { \
+        if (adaptive_enabled) { \
+            (COUNTER) = advance_backoff_counter((COUNTER)); \
+        } \
+    } while (0);
+#else
+#define ADVANCE_ADAPTIVE_COUNTER(COUNTER) \
+    do { \
         (COUNTER) = advance_backoff_counter((COUNTER)); \
-    }
+    } while (0);
+#endif
 
 #define PAUSE_ADAPTIVE_COUNTER(COUNTER) \
     do { \
@@ -431,6 +440,7 @@ do { \
 
 // CO_NO_MONITORING_EVENTS indicates the code object is read-only and therefore
 // cannot have code-extra data added.
+#ifdef CINDER_ENABLE_STATIC_PYTHON
 #define CI_SET_ADAPTIVE_INTERPRETER_ENABLED_STATE \
     do { \
         PyObject *executable = PyStackRef_AsPyObjectBorrow(frame->f_executable); \
@@ -459,3 +469,20 @@ do { \
             } \
         } \
     } while (0);
+
+#else
+#define CI_SET_ADAPTIVE_INTERPRETER_ENABLED_STATE ((void)0);
+#define CI_UPDATE_CALL_COUNT \
+    do { \
+        PyObject *executable = PyStackRef_AsPyObjectBorrow(frame->f_executable); \
+        if (PyCode_Check(executable)) { \
+            PyCodeObject* code = (PyCodeObject*)executable; \
+            if (!(code->co_flags & CO_NO_MONITORING_EVENTS)) { \
+                CodeExtra *extra = codeExtra(code); \
+                if (extra != NULL) { \
+                    Ci_code_extra_incr_calls(extra); \
+                } \
+            } \
+        } \
+    } while (0);
+#endif

--- a/cinderx/PythonLib/cinderx.pth
+++ b/cinderx/PythonLib/cinderx.pth
@@ -1,0 +1,1 @@
+import builtins, cinderx; builtins.cinderx = cinderx

--- a/cinderx/_cinderx-lib.cpp
+++ b/cinderx/_cinderx-lib.cpp
@@ -1609,7 +1609,9 @@ int _cinderx_exec_impl(PyObject* m) {
   if (_Ci_CreateStaticModule() < 0) {
     return -1;
   }
-
+  if (Ci_InitFrameEvalFunc() < 0) {
+    return -1;
+  }
   return 0;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -407,7 +407,11 @@ class BuildPy(build_py):
         print(f"Writing .dev_build file to {dev_build_file}")
         with open(dev_build_file, "w") as f:
             f.write("\n")
-
+        # Copy .pth file to build_lib root for auto-import on Python startup
+        pth_source = os.path.join(PYTHON_LIB_DIR, "cinderx.pth")
+        pth_dest = os.path.join(self.build_lib, "cinderx.pth")
+        print(f"Copying .pth file to {pth_dest}")
+        self.copy_file(pth_source, pth_dest, preserve_mode=False)
 
 class CMakeExtension(Extension):
     """


### PR DESCRIPTION
### 概述
本 PR 包含两项改进：

1. Static Python 宏的编译时隔离 - 使用条件编译将 Static Python 和非 Static Python 的执行路径分离，当 Static Python 禁用时消除不必要的运行时检查。
2. 自动初始化支持 - 支持 pip 安装后自动初始化 CinderX，提升开箱即用的用户体验。
### 变更详情
 1. Static Python 宏的编译时隔离 ( 8a801b46 )
文件: cinderx/Interpreter/3.14/Includes/ceval_macros.h

使用 #ifdef CINDER_ENABLE_STATIC_PYTHON 对以下宏进行编译时分支处理：

- ADVANCE_ADAPTIVE_COUNTER : 当 CINDER_ENABLE_STATIC_PYTHON 未定义时，宏直接推进计数器，无需检查 adaptive_enabled ，消除运行时开销。
- CI_SET_ADAPTIVE_INTERPRETER_ENABLED_STATE : 当 Static Python 禁用时，宏变为空操作 ((void)0) 。
优势:

- Static Python 编译时禁用时零运行时开销
- Static Python 与非 Static Python 代码路径清晰分离
- 与提交 70fdffdd 引入的 ENABLE_STATIC_PYTHON 编译时开关保持一致 2. 自动初始化支持 ( 92e48db6 )
文件:

- cinderx/PythonLib/cinderx.pth (新增)
- cinderx/_cinderx-lib.cpp
- setup.py
添加自动初始化机制：

- cinderx.pth 确保 Python 启动时自动导入 CinderX
- 模块初始化时调用 Ci_InitFrameEvalFunc()
- 用户无需手动 import cinderx 即可启用 JIT 功能
优势:

- 提升用户体验 - pip install cinderx 后 JIT 自动生效
- 与 README 中描述的 cinderx.jit.auto() 行为一致

### 说明
如果你要基于pyperformance测试性能用例，应当了解下述知识，并且做相应的修改（以pyperformance 1.13.0为例）
- pyperformance适配：由于虚拟环境不继承system-site-packages，导致主进程可以无感导入cinderx，但是子进程不行
```
┌─────────────────────────────────────────────────────────────────┐
│  主进程 (pyperformance/pyperf Runner)                            │
│                                                                  │
│  1. Run 1: 启动第一个 worker 进程进行校准                         │
│     - 计算合适的循环次数 (loops)                                  │
│                                                                  │
│  2. Run 2-21: 启动 20 个 worker 进程执行实际测试                   │
│     每个 worker 进程内部:                                         │
│     ┌────────────────────────────────────────────────────────┐   │
│     │  Worker Process (独立子进程)                            │  │
│     │                                                         │  │
│     │  Step 1: Warmup (预热)                                  │  │
│     │     - 执行基准测试 1 次                                  │  │
│     │     - 结果被忽略，不计入最终结果                         │  │
│     │                                                         │  │
│     │  Step 2: 实际测试                                       │  │
│     │     - 执行基准测试 3 次 (默认)                           │  │
│     │     - 结果被记录到最终结果中                             │  │
│     └────────────────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────────────────┘
```
- 修改方式：接修改pyperformance的创建环境脚本
```
## 找到pyperformance创建环境的脚本，通常在site-packages目录下，如：/home/pyBin/lib/python3.14/site-packages/pyperformance/_venv.py
## 修改脚本，补充创建环境需要集成的变量--system-site-packages
def create_venv(
    root,
    python=sys.executable,
    *,
    env=None,
    downloaddir=None,
    withpip=True,
    cleanonfail=True,
):
    """Create a new venv at the given root, optionally installing pip."""
    already_existed = os.path.exists(root)
    if withpip:
        # 修改位置1 :原本代码  args = ["-m", "venv", root]
        args = ["-m", "venv", "--system-site-packages", root]
    else:
        # 修改位置2 ：原本代码 args = ["-m", "venv", "--without-pip", root]
        args = ["-m", "venv", "--without-pip", "--system-site-packages", root]
    ec, _, _ = _utils.run_python(*args, python=python, env=env)
    if ec != 0:
        if cleanonfail and not already_existed:
            _utils.safe_rmtree(root)
        raise VenvCreationFailedError(root, ec, already_existed)
    return resolve_venv_python(root)
```
- pyperformance使用方法举例：
```
# 其中jit_list.txt内容为“__main__:*”
PYTHONJITENABLEJITLISTWILDCARDS=1 PYTHONJITAUTO=3 PYTHONJITSPECIALIZEDOPCODES=1 PYTHONJITLISTFILE=/home/jit_list.txt /home/pyBin/bin/python3.14 -m pyperformance run --affinity=200-205 -b spectral_norm --warmup 5 --inherit-environ http_proxy,https_proxy,LD_LIBRARY_PATH,PYTHONJITAUTO,PYTHONJITSPECIALIZEDOPCODES,PYTHONJITLISTFILE,PYTHONJITENABLEJITLISTWILDCARDS  
```