### PR TITLE
 修复 ARM64 tstate TLS 偏移检测：修正掩码常量并支持无 prologue 的 mrs 开头

### DIFF
--- a/cinderx/Jit/codegen/frame_asm.cpp
+++ b/cinderx/Jit/codegen/frame_asm.cpp
@@ -92,19 +92,31 @@ void initThreadStateOffset() {
   // out that offset.
   uint32_t* ts_func = reinterpret_cast<uint32_t*>(&_PyThreadState_GetCurrent);
 
+  size_t scan_start = 0;
+  uint32_t reg = 0;
+  bool matched = false;
+
   if (ts_func[0] == 0xa9bf7bfd && // stp x29, x30, [sp, #-16]!
       ts_func[1] == 0x910003fd && // mov x29, sp
-      ((ts_func[2] & ~0x1f) == 0xd53bd048) // mrs x?, tpidr_el0
+      ((ts_func[2] & ~0x1f) == 0xd53bd040) // mrs x?, tpidr_el0
   ) {
     // Here we know we are loading the thread local base offset into some
     // register, based on the mrs instruction.
-    uint32_t reg = ts_func[2] & 0x1f;
-    int32_t current_offset = 0;
+    reg = ts_func[2] & 0x1f;
+    scan_start = 3;
+    matched = true;
+  } else if ((ts_func[0] & ~0x1f) == 0xd53bd040) { // mrs x?, tpidr_el0 (no prologue)
+    reg = ts_func[0] & 0x1f;
+    scan_start = 1;
+    matched = true;
+  } 
 
+  if (matched) {
+    int32_t current_offset = 0;
     // Now, we will interpret any subsequent add instructions in order to
     // determine the offset. We will know we are done when we hit an ldr x0, or
     // we hit something unknown and need to break.
-    for (size_t index = 3;; index++) {
+    for (size_t index = scan_start;; index++) {
       if (ts_func[index] == (0xf9400000 | (reg << 5))) {
         // ldr x0, [x?]
         //
@@ -134,7 +146,7 @@ void initThreadStateOffset() {
 
     tstate_offset = current_offset;
   }
-
+} // if matched
 #ifndef Py_DEBUG
   if (tstate_offset == -1) {
     assert(false);


### PR DESCRIPTION
**描述：**

`initThreadStateOffset()` 在运行时反汇编 `_PyThreadState_GetCurrent` 函数，从中提取 `PyThreadState` 的 TLS 偏移量，使 JIT 能够内联线程状态访问。现有的 ARM64 实现存在两个问题：

**Bug 修复：掩码比较常量错误**

原始代码用 `~0x1f` 掩掉 `mrs` 指令的寄存器域后，与 `0xd53bd048` 进行比较。这个比较永远不可能成功：`~0x1f`（即 `0xFFFFFFE0`）会将 bit[4:0] 全部清零，但比较目标 `0xd53bd048` 的 bit[3] 为 1（对应寄存器编号 x8 的残留）。`mrs Xt, tpidr_el0` 掩掉寄存器域后的正确基准编码应为 `0xd53bd040`。这意味着在所有 ARM64 构建上，TLS 偏移检测实际上从未成功过，`tstate_offset` 始终保持 -1 的默认值，JIT 无法利用此优化路径。

**新增模式：支持无 prologue 的叶函数**

部分工具链（尤其在较高优化等级或启用 LTO 的情况下）会将 `_PyThreadState_GetCurrent` 编译为叶函数，省略 `stp x29, x30` / `mov x29, sp` 的帧指针 prologue，函数直接以 `mrs Xn, tpidr_el0` 开头。新增 `else if` 分支匹配该模式，并将 `scan_start` 设为 1，使后续的 `add`/`ldr` 指令扫描从正确的位置开始。

扫描循环和偏移量累加逻辑本身未做改动。

经测试，很多用例能提升1%的性能