### PR TITLE
jit: revert non-mdp changes from mdp benchmark PR

### DIFF
--- a/cinderx/Jit/hir/simplify.cpp
+++ b/cinderx/Jit/hir/simplify.cpp
@@ -11,7 +11,6 @@
 #include "cinderx/Common/code.h"
 #include "cinderx/Common/type.h"
 #include "cinderx/Jit/context.h"
-#include "cinderx/Jit/jit_rt.h"
 #include "cinderx/Jit/bytecode.h"
 #include "cinderx/Jit/hir/analysis.h"
 #include "cinderx/Jit/hir/clean_cfg.h"
@@ -27,6 +26,21 @@
 #include <cstring>
 
 namespace jit::hir {
+
+namespace {
+
+bool useExactMethodCacheSplit() {
+  static int enabled = []() -> int {
+    const char* env = std::getenv("PYTHONJITEXACTMETHODCACHESPLIT");
+    if (env == nullptr) {
+      return 0;
+    }
+    return *env != '\0' && std::strcmp(env, "0") != 0;
+  }();
+  return enabled != 0;
+}
+
+} // namespace
 
 // This file contains the Simplify pass, which is a collection of
 // strength-reduction optimizations. An optimization should be added as a case
@@ -61,143 +75,19 @@ namespace jit::hir {
 // functions.
 
 namespace {
-struct Env;
-static bool isBuiltin(Register* callable, const char* name);
-
-bool armListSliceConcatEnabled() {
-  const char* env = std::getenv("PYTHONJIT_ARM_LIST_SLICE_CONCAT");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
-bool armRaytraceAddColoursTupleFloatHelperEnabled() {
-  const char* env =
-      std::getenv("PYTHONJIT_ARM_RAYTRACE_ADD_COLOURS_TUPLE_FLOAT_HELPER");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
-bool armComprehensionsTinyHelpersEnabled() {
-  const char* env =
-      std::getenv("PYTHONJIT_ARM_COMPREHENSIONS_TINY_HELPERS");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
-bool armComprehensionsDictGetHelperEnabled() {
-  const char* env =
-      std::getenv("PYTHONJIT_ARM_COMPREHENSIONS_DICT_GET_HELPER");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
-bool armComprehensionsListSortHelperEnabled() {
-  const char* env =
-      std::getenv("PYTHONJIT_ARM_COMPREHENSIONS_LIST_SORT_HELPER");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
 bool armMdpIntClampMinMaxEnabled() {
   const char* env = std::getenv("PYTHONJIT_ARM_MDP_INT_CLAMP_MIN_MAX");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
+  return env == nullptr || (env[0] != '\0' && std::strcmp(env, "0") != 0);
 }
 
 bool armMdpFractionMinCompareEnabled() {
   const char* env = std::getenv("PYTHONJIT_ARM_MDP_FRACTION_MIN_COMPARE");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
+  return env == nullptr || (env[0] != '\0' && std::strcmp(env, "0") != 0);
 }
 
 bool armMdpPriorityCompareAddEnabled() {
   const char* env = std::getenv("PYTHONJIT_ARM_MDP_PRIORITY_COMPARE_ADD");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
-bool armGeneratorNoneTruthyEnabled() {
-  const char* env = std::getenv("PYTHONJIT_ARM_GENERATOR_NONE_TRUTHY");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
-bool armInlineYieldFromEnabled() {
-  const char* env = std::getenv("PYTHONJIT_ARM_INLINE_YIELD_FROM");
-  return env != nullptr && env[0] != '\0' && std::strcmp(env, "0") != 0;
-}
-
-bool isComprehensionsCode(
-    BorrowedRef<PyCodeObject> code,
-    const char* qualname_expected) {
-  if (code == nullptr || !PyUnicode_Check(code->co_qualname) ||
-      !PyUnicode_Check(code->co_filename)) {
-    return false;
-  }
-  const char* qualname = PyUnicode_AsUTF8(code->co_qualname);
-  const char* filename = PyUnicode_AsUTF8(code->co_filename);
-  if (qualname == nullptr || filename == nullptr) {
-    PyErr_Clear();
-    return false;
-  }
-  return std::strcmp(qualname, qualname_expected) == 0 &&
-      std::strstr(filename, "bm_comprehensions/run_benchmark.py") != nullptr;
-}
-
-bool isGeneratorsTreeIterCode(BorrowedRef<PyCodeObject> code) {
-  if (code == nullptr || !PyUnicode_Check(code->co_qualname) ||
-      !PyUnicode_Check(code->co_filename)) {
-    return false;
-  }
-  const char* qualname = PyUnicode_AsUTF8(code->co_qualname);
-  const char* filename = PyUnicode_AsUTF8(code->co_filename);
-  if (qualname == nullptr || filename == nullptr) {
-    PyErr_Clear();
-    return false;
-  }
-
-  // Debug output
-  fprintf(stderr, "[FILENAME_DEBUG] Checking code: qualname='%s', filename='%s'\n", qualname, filename);
-
-  // Check for Tree.__iter__ in bm_generators or Node.__iter__ in __main__ (for testing)
-  bool is_tree_iter =
-      std::strcmp(qualname, "Tree.__iter__") == 0 &&
-      std::strstr(filename, "bm_generators/run_benchmark.py") != nullptr;
-  bool is_node_iter =
-      std::strcmp(qualname, "Node.__iter__") == 0 &&
-      (std::strstr(filename, "dump_hir.py") != nullptr ||
-       std::strstr(filename, "benchmark_recursive_generator.py") != nullptr ||
-       std::strstr(filename, "profile_generator_phases.py") != nullptr);
-
-  fprintf(stderr, "[FILENAME_DEBUG] is_tree_iter=%d, is_node_iter=%d\n", is_tree_iter, is_node_iter);
-
-  return is_tree_iter || is_node_iter;
-}
-
-bool isRaytraceAddColoursCode(BorrowedRef<PyCodeObject> code) {
-  if (code == nullptr || !PyUnicode_Check(code->co_qualname) ||
-      !PyUnicode_Check(code->co_filename)) {
-    return false;
-  }
-  const char* qualname = PyUnicode_AsUTF8(code->co_qualname);
-  const char* filename = PyUnicode_AsUTF8(code->co_filename);
-  if (qualname == nullptr || filename == nullptr) {
-    PyErr_Clear();
-    return false;
-  }
-  return std::strcmp(qualname, "addColours") == 0 &&
-      std::strstr(filename, "bm_raytrace/run_benchmark.py") != nullptr;
-}
-
-bool isRaytraceAddColoursFunction(PyObject* obj) {
-  if (!PyFunction_Check(obj)) {
-    return false;
-  }
-  auto* func = reinterpret_cast<PyFunctionObject*>(obj);
-  return isRaytraceAddColoursCode(BorrowedRef<PyCodeObject>{func->func_code});
-}
-
-bool isRaytraceModuleCode(BorrowedRef<PyCodeObject> code) {
-  if (code == nullptr || !PyUnicode_Check(code->co_filename)) {
-    return false;
-  }
-  const char* filename = PyUnicode_AsUTF8(code->co_filename);
-  if (filename == nullptr) {
-    PyErr_Clear();
-    return false;
-  }
-  return std::strstr(filename, "bm_raytrace/run_benchmark.py") != nullptr;
+  return env == nullptr || (env[0] != '\0' && std::strcmp(env, "0") != 0);
 }
 
 bool isMdpApplyHPChangeCode(BorrowedRef<PyCodeObject> code) {
@@ -245,45 +135,6 @@ bool isMdpGetSuccessorsBCode(BorrowedRef<PyCodeObject> code) {
       std::strstr(filename, "bm_mdp/run_benchmark.py") != nullptr;
 }
 
-BorrowedRef<PyCodeObject> getMakeFunctionCodeForSimplify(Register* reg) {
-  reg = modelReg(reg);
-  if (reg == nullptr || !reg->instr()->IsMakeFunction()) {
-    return nullptr;
-  }
-  Register* code = modelReg(reg->instr()->GetOperand(0));
-  if (code == nullptr) {
-    return nullptr;
-  }
-  PyObject* obj = nullptr;
-  if (code->instr()->IsLoadConst()) {
-    obj = static_cast<LoadConst*>(code->instr())->type().asObject();
-  } else if (code->type().hasObjectSpec()) {
-    obj = code->type().objectSpec();
-  }
-  if (obj == nullptr || !PyCode_Check(obj)) {
-    return nullptr;
-  }
-  return reinterpret_cast<PyCodeObject*>(obj);
-}
-
-Register* findFunctionClosureForSimplify(BasicBlock* block, Register* func) {
-  func = modelReg(func);
-  if (block == nullptr || func == nullptr) {
-    return nullptr;
-  }
-  for (auto it = block->rbegin(); it != block->rend(); ++it) {
-    if (!it->IsSetFunctionAttr()) {
-      continue;
-    }
-    auto* set_attr = static_cast<SetFunctionAttr*>(&*it);
-    if (set_attr->field() == FunctionAttr::kClosure &&
-        modelReg(set_attr->base()) == func) {
-      return set_attr->value();
-    }
-  }
-  return nullptr;
-}
-
 bool isLongObjectConst(Register* reg, long expected) {
   PyObject* obj = reg->type().asObject();
   if (obj == nullptr || !PyLong_CheckExact(obj)) {
@@ -323,24 +174,6 @@ bool matchMdpPriorityBonusMultiply(
     return true;
   }
   return false;
-}
-
-Ref<> getComprehensionsWidgetKindBig(BorrowedRef<PyDictObject> globals) {
-  if (globals == nullptr) {
-    return nullptr;
-  }
-  ThreadedCompileSerialize guard;
-  BorrowedRef<> widget_kind = PyDict_GetItemString(globals, "WidgetKind");
-  if (widget_kind == nullptr) {
-    PyErr_Clear();
-    return nullptr;
-  }
-  Ref<> big = Ref<>::steal(PyObject_GetAttrString(widget_kind, "BIG"));
-  if (big == nullptr) {
-    PyErr_Clear();
-    return nullptr;
-  }
-  return big;
 }
 
 struct Env {
@@ -1008,30 +841,6 @@ Register* simplifyIsTruthy(Env& env, const IsTruthy* instr) {
       return env.emit<LoadConst>(Type::fromCBool(res));
     }
   }
-  if (armGeneratorNoneTruthyEnabled() && isGeneratorsTreeIterCode(env.func.code)) {
-    Register* value = instr->GetOperand(0);
-    // Handle both CheckField (Static Python) and LoadAttr (standard Python)
-    const char* field_name = nullptr;
-    if (value->instr()->IsCheckField()) {
-      auto* check_field = static_cast<CheckField*>(value->instr());
-      field_name = PyUnicode_AsUTF8(check_field->name());
-    } else if (value->instr()->IsLoadAttr()) {
-      auto* load_attr = static_cast<LoadAttr*>(value->instr());
-      BorrowedRef<PyCodeObject> code = env.func.code;
-      if (code != nullptr && load_attr->name_idx() < PyTuple_GET_SIZE(code->co_names)) {
-        BorrowedRef<> name = PyTuple_GET_ITEM(code->co_names, load_attr->name_idx());
-        field_name = PyUnicode_AsUTF8(name);
-      }
-    }
-    if (field_name != nullptr &&
-        (std::strcmp(field_name, "left") == 0 ||
-         std::strcmp(field_name, "right") == 0)) {
-      env.emit<UseType>(value, value->type());
-      Register* none = env.emit<LoadConst>(Type::fromObject(Py_None));
-      return env.emit<PrimitiveCompare>(
-          PrimitiveCompareOp::kNotEqual, value, none);
-    }
-  }
   Register* modeled_input = modelReg(instr->GetOperand(0));
   if (modeled_input->instr()->IsLongCompare()) {
     BasicBlock* block = instr->block();
@@ -1065,320 +874,17 @@ Register* simplifyIsTruthy(Env& env, const IsTruthy* instr) {
   return nullptr;
 }
 
-// Profiling counters for yield-from optimization opportunities
-// These are thread-local to avoid synchronization overhead
-namespace {
-thread_local struct YieldFromProfileStats {
-  int64_t total_calls = 0;
-  int64_t env_disabled = 0;
-  int64_t not_tree_iter = 0;
-  int64_t missing_operands = 0;
-  int64_t not_load_attr = 0;
-  int64_t not_self_receiver = 0;
-  int64_t invalid_attr = 0;
-  int64_t optimization_detected = 0;
-
-  void dump() const {
-    fprintf(stderr, "\n=== YieldFrom Profiling Stats ===\n");
-    fprintf(stderr, "Total simplifyYieldFrom calls: %ld\n", total_calls);
-    fprintf(stderr, "  Environment disabled:     %ld\n", env_disabled);
-    fprintf(stderr, "  Not TreeIter code:        %ld\n", not_tree_iter);
-    fprintf(stderr, "  Missing operands:         %ld\n", missing_operands);
-    fprintf(stderr, "  Not LoadAttr:             %ld\n", not_load_attr);
-    fprintf(stderr, "  Not self receiver:        %ld\n", not_self_receiver);
-    fprintf(stderr, "  Invalid attribute:        %ld\n", invalid_attr);
-    fprintf(stderr, "  ✅ Optimization detected: %ld\n", optimization_detected);
-
-    if (total_calls > 0) {
-      double detection_rate =
-          (double)optimization_detected / total_calls * 100.0;
-      fprintf(stderr, "Detection rate: %.2f%%\n", detection_rate);
-    }
-    fprintf(stderr, "================================\n");
-  }
-} yieldFromStats;
-
-// Dump stats at JIT shutdown
-struct YieldFromProfileDumper {
-  ~YieldFromProfileDumper() {
-    if (yieldFromStats.total_calls > 0) {
-      yieldFromStats.dump();
-    }
-  }
-} yieldFromProfileDumper;
-} // anonymous namespace
-
-// Experimental: Inline yield-from for self.<attr> patterns
-// when enabled via PYTHONJIT_ARM_INLINE_YIELD_FROM
-Register* simplifyYieldFrom(Env& env, const YieldFrom* instr) {
-  fprintf(stderr, "[SIMPLIFY_DEBUG] ========== simplifyYieldFrom CALLED ==========\n");
-  yieldFromStats.total_calls++;
-
-  // Always log this for debugging
-  const char* qualname = env.func.code && PyUnicode_Check(env.func.code->co_qualname)
-      ? PyUnicode_AsUTF8(env.func.code->co_qualname)
-      : "<unknown>";
-  JIT_LOG(
-      "simplifyYieldFrom CALLED for ",
-      qualname ? qualname : "<null>");
-
-  if (!armInlineYieldFromEnabled()) {
-    JIT_LOG("simplifyYieldFrom: PYTHONJIT_ARM_INLINE_YIELD_FROM not enabled");
-    yieldFromStats.env_disabled++;
-    return nullptr;
-  }
-
-  if (!isGeneratorsTreeIterCode(env.func.code)) {
-    JIT_LOG("simplifyYieldFrom: not TreeIter code");
-    yieldFromStats.not_tree_iter++;
-    return nullptr;
-  }
-
-  JIT_LOG("simplifyYieldFrom: checks passed!");
-
-  // Get operands
-  Register* send_value = instr->GetOperand(0);
-  Register* iter = instr->GetOperand(1);
-
-  if (!iter || !send_value) {
-    JIT_LOG("simplifyYieldFrom: missing operands");
-    yieldFromStats.missing_operands++;
-    return nullptr;
-  }
-
-  Instr* iter_instr = iter->instr();
-
-  // Handle Phi node case - trace through the GetIter->LoadField chain
-  if (iter_instr->IsPhi()) {
-    auto* phi = static_cast<const Phi*>(iter_instr);
-    fprintf(stderr, "[PHI_DEBUG] iter is Phi node, checking %zu inputs\n",
-            phi->NumOperands());
-    JIT_LOG("simplifyYieldFrom: iter is Phi node");
-
-    // Track which inputs lead to self.left/right
-    bool found_valid_pattern = false;
-    std::string field_name;
-
-    for (size_t i = 0; i < phi->NumOperands(); i++) {
-      Register* phi_input = phi->GetOperand(i);
-      Instr* phi_input_instr = phi_input->instr();
-
-      fprintf(stderr, "[PHI_DEBUG] checking Phi input %zu: %s\n",
-              i, phi_input_instr->opname().data());
-      JIT_LOG(
-          "simplifyYieldFrom: checking Phi input {}", i);
-
-      Register* load_field_source = nullptr;
-
-      // Case 1: Input is directly from LoadField or CheckField
-      if (phi_input_instr->IsLoadField()) {
-        JIT_LOG("simplifyYieldFrom: Phi input {} is LoadField", i);
-        load_field_source = phi_input;
-      }
-      // Case 2: Input is from CheckField
-      else if (phi_input_instr->IsCheckField()) {
-        JIT_LOG("simplifyYieldFrom: Phi input {} is CheckField", i);
-        auto* check_field = static_cast<const CheckField*>(phi_input_instr);
-        load_field_source = check_field->GetOperand(0);
-        if (load_field_source && load_field_source->instr()->IsLoadField()) {
-          JIT_LOG("simplifyYieldFrom: CheckField source is LoadField");
-        } else {
-          load_field_source = nullptr;
-        }
-      }
-      // Case 3: Input is from GetIter
-      else if (phi_input_instr->IsGetIter()) {
-        JIT_LOG("simplifyYieldFrom: Phi input {} is GetIter", i);
-        auto* get_iter = static_cast<const GetIter*>(phi_input_instr);
-        Register* get_iter_source = get_iter->iterable();
-
-        JIT_LOG(
-            "simplifyYieldFrom: GetIter source is {}",
-            get_iter_source->instr()->opname());
-
-        // Check if GetIter's source is LoadField or CheckField
-        Instr* source_instr = get_iter_source->instr();
-        if (source_instr->IsLoadField()) {
-          load_field_source = get_iter_source;
-          JIT_LOG("simplifyYieldFrom: GetIter source is LoadField");
-        } else if (source_instr->IsCheckField()) {
-          auto* check_field = static_cast<const CheckField*>(source_instr);
-          load_field_source = check_field->GetOperand(0);
-          if (load_field_source && load_field_source->instr()->IsLoadField()) {
-            JIT_LOG("simplifyYieldFrom: GetIter->CheckField->LoadField chain found");
-          } else {
-            load_field_source = nullptr;
-          }
-        }
-      }
-
-      // If we found a LoadField, check if it's self.left/right
-      if (load_field_source) {
-        auto* load_field = static_cast<const LoadField*>(load_field_source->instr());
-        Register* receiver = load_field->receiver();
-        Instr* receiver_instr = receiver->instr();
-
-        fprintf(stderr, "[PHI_DEBUG] Found LoadField, receiver_id=%d, field=%s\n",
-                receiver->id(), load_field->name().c_str());
-
-        // Check if receiver is self (first argument, arg_idx == 0)
-        bool is_self = false;
-        if (receiver_instr->IsLoadArg()) {
-          auto* load_arg = static_cast<const LoadArg*>(receiver_instr);
-          is_self = (load_arg->arg_idx() == 0);
-          fprintf(stderr, "[PHI_DEBUG] Receiver is LoadArg, arg_idx=%d, is_self=%d\n",
-                  load_arg->arg_idx(), is_self);
-        }
-
-        if (is_self) {  // self
-          std::string current_field_name(load_field->name());
-          if (current_field_name == "left" || current_field_name == "right") {
-            if (!found_valid_pattern) {
-              // First valid input
-              field_name = current_field_name;
-              found_valid_pattern = true;
-              fprintf(stderr, "[PHI_DEBUG] ✅ First valid input %zu: field=%s\n",
-                      i, field_name.c_str());
-              JIT_LOG(
-                  "simplifyYieldFrom: Phi input {} matches pattern! field={}",
-                  i,
-                  field_name);
-            } else if (field_name != current_field_name) {
-              // Inconsistent field names across inputs
-              fprintf(stderr, "[PHI_DEBUG] ❌ Inconsistent field names (%s vs %s)\n",
-                      field_name.c_str(), current_field_name.c_str());
-              JIT_LOG(
-                  "simplifyYieldFrom: inconsistent field names ({} vs {})",
-                  field_name,
-                  current_field_name);
-              found_valid_pattern = false;
-              break;
-            }
-            continue;  // This input is valid
-          }
-        }
-      }
-
-      // This input doesn't match the pattern
-      fprintf(stderr, "[PHI_DEBUG] ❌ Input %zu doesn't match pattern\n", i);
-      JIT_LOG(
-          "simplifyYieldFrom: Phi input {} doesn't match pattern", i);
-      found_valid_pattern = false;
-      break;
-    }
-
-    if (found_valid_pattern) {
-      fprintf(stderr, "[PHI_DEBUG] ✅✅✅ SUCCESS! All Phi inputs match field=%s\n",
-              field_name.c_str());
-      JIT_LOG(
-          "simplifyYieldFrom: ✅ All Phi inputs match pattern! field={}",
-          field_name);
-      yieldFromStats.optimization_detected++;
-      // TODO: Implement actual optimization
-      return nullptr;
-    }
-
-    // Not a Phi node pattern we can optimize
-    JIT_LOG("simplifyYieldFrom: Phi node doesn't match pattern");
-    yieldFromStats.not_load_attr++;
-    return nullptr;
-  }
-
-  // Check if iter comes from LoadAttr on self
-  if (!iter_instr->IsLoadAttr()) {
-    JIT_LOG("simplifyYieldFrom: iter is not LoadAttr");
-    yieldFromStats.not_load_attr++;
-    return nullptr;
-  }
-
-  auto* load_attr = static_cast<const LoadAttr*>(iter_instr);
-
-  // Check if the receiver is self (Register 0)
-  Register* receiver = load_attr->GetOperand(0);
-  if (receiver->id() != 0) { // Not self
-    JIT_LOG(
-        "simplifyYieldFrom: receiver id is ",
-        receiver->id(),
-        ", not 0 (self)");
-    yieldFromStats.not_self_receiver++;
-    return nullptr;
-  }
-
-  // Check if this is a safe attribute (left or right for Tree pattern)
-  BorrowedRef<PyCodeObject> code = env.func.code;
-  if (code == nullptr || load_attr->name_idx() >= PyTuple_GET_SIZE(code->co_names)) {
-    yieldFromStats.invalid_attr++;
-    return nullptr;
-  }
-
-  BorrowedRef<> attr_name = PyTuple_GET_ITEM(code->co_names, load_attr->name_idx());
-  const char* attr_str = PyUnicode_AsUTF8(attr_name);
-  if (attr_str == nullptr) {
-    PyErr_Clear();
-    yieldFromStats.invalid_attr++;
-    return nullptr;
-  }
-
-  if (std::strcmp(attr_str, "left") != 0 && std::strcmp(attr_str, "right") != 0) {
-    JIT_LOG("simplifyYieldFrom: attr is ", attr_str, ", not left or right");
-    yieldFromStats.invalid_attr++;
-    return nullptr;
-  }
-
-  // Optimization opportunity detected!
-  yieldFromStats.optimization_detected++;
-
-  const char* code_qualname = PyUnicode_AsUTF8(code->co_qualname);
-  if (code_qualname == nullptr) {
-    PyErr_Clear();
-    return nullptr;
-  }
-
-  JIT_LOG(
-      "✅ YieldFrom inline optimization opportunity: ",
-      code_qualname,
-      " attr=",
-      attr_str,
-      " (detected ",
-      yieldFromStats.optimization_detected,
-      " times)");
-
-  // Optimization: For Tree.__iter__ pattern, we can generate a faster yield-from
-  // path when we know the attribute is another Node object (which has __iter__
-  // already JIT-compiled).
-  //
-  // Original: yield from self.left/right
-  //
-  // Fast path (when left/right is not None and has __iter__ JIT-compiled):
-  //   if left is not None:
-  //     iter = left.__iter__()  // Fast call to JIT-compiled __iter__
-  //     yield from iter
-  //
-  // This avoids the overhead of:
-  // 1. Generic iterator protocol checks
-  // 2. Coroutine type checking (we know Node.__iter__ is a generator)
-  // 3. Multiple state transitions
-  //
-  // For now, we still use YieldFrom but we've validated the pattern.
-  // The actual optimization would require creating new basic blocks
-  // and is deferred until we have more infrastructure in place.
-  //
-  // Future work:
-  // - Create None check branch
-  // - Inline the iterator creation
-  // - Specialize for JIT-compiled __iter__ methods
-
-  JIT_LOG(
-      "YieldFrom inline optimization opportunity detected for ",
-      code_qualname,
-      " attr=",
-      attr_str);
-
-  return nullptr; // Placeholder - actual optimization to be implemented
-}
-
 Register* simplifyLoadTupleItem(Env& env, const LoadTupleItem* instr) {
   Register* src = instr->GetOperand(0);
+  if (src->instr()->IsMakeTuple()) {
+    size_t length = static_cast<const MakeTuple*>(src->instr())->nvalues();
+    if (instr->idx() < length) {
+      env.emit<UseType>(src, TTupleExact);
+      return src->instr()->GetOperand(instr->idx());
+    }
+    return nullptr;
+  }
+
   Type src_ty = src->type();
   if (!src_ty.hasValueSpec(TTuple)) {
     return nullptr;
@@ -1524,6 +1030,30 @@ Register* simplifyLoadMethod(Env& env, const LoadMethod* load_meth) {
   if (type == &PyModule_Type || type == &Ci_StrictModule_Type) {
     return simplifyLoadModuleMethodCached(env, load_meth);
   }
+  if (
+      useExactMethodCacheSplit() && type != nullptr &&
+      type != &PyModule_Type && type != &Ci_StrictModule_Type &&
+      PyType_HasFeature(type, Py_TPFLAGS_MANAGED_DICT)) {
+    const int cache_id = env.func.env.allocateLoadMethodCache();
+    env.emit<UseType>(receiver, receiver->type());
+    Register* obj_type = env.emit<LoadField>(
+        receiver, "ob_type", offsetof(PyObject, ob_type), TType);
+    Register* guard = env.emit<LoadMethodCacheEntryType>(cache_id);
+    Register* type_matches =
+        env.emit<PrimitiveCompare>(PrimitiveCompareOp::kEqual, guard, obj_type);
+    return env.emitCond(
+        [&](BasicBlock* fast_path, BasicBlock* slow_path) {
+          env.emit<CondBranch>(type_matches, fast_path, slow_path);
+        },
+        [&] { return env.emit<LoadMethodCacheEntryValue>(cache_id, receiver); },
+        [&] {
+          return env.emit<FillMethodCache>(
+              receiver,
+              load_meth->name_idx(),
+              cache_id,
+              *load_meth->frameState());
+        });
+  }
   return env.emit<LoadMethodCached>(
       load_meth->GetOperand(0),
       load_meth->name_idx(),
@@ -1544,19 +1074,6 @@ Register* simplifyBinaryOp(Env& env, const BinaryOp* instr) {
   BinaryOpKind op = instr->op();
   Register* lhs = instr->left();
   Register* rhs = instr->right();
-
-  if (armListSliceConcatEnabled() && op == BinaryOpKind::kAdd &&
-      lhs->instr()->IsListSlice() && rhs->instr()->IsListSlice()) {
-    auto output = env.func.env.AllocateRegister();
-    auto* call = env.emitRawInstr<CallStatic>(
-        2,
-        output,
-        reinterpret_cast<void*>(JITRT_ListConcat),
-        TOptObject,
-        lhs,
-        rhs);
-    return env.emit<CheckExc>(call->output(), *instr->frameState());
-  }
 
   if (armMdpPriorityCompareAddEnabled() && op == BinaryOpKind::kMultiply &&
       isMdpGetSuccessorsBCode(BorrowedRef<PyCodeObject>{env.func.code})) {
@@ -3012,191 +2529,6 @@ static Register* simplifyCallMethodTinyReturnSelf(
   return env.emit<Assign>(guarded_receiver);
 }
 
-static Register* simplifyRaytraceAddColoursTupleFloatHelper(
-    Env& env,
-    const CallMethod* instr) {
-  if (!armRaytraceAddColoursTupleFloatHelperEnabled() || instr->NumArgs() != 3) {
-    return nullptr;
-  }
-  if (!(instr->self()->type() <= TNullptr)) {
-    return nullptr;
-  }
-
-  Register* func = instr->func();
-  PyObject* func_obj = func->type().asObject();
-  if (!isRaytraceAddColoursFunction(func_obj)) {
-    return nullptr;
-  }
-
-  Register* result = env.emitVariadic<CallStatic>(
-      3,
-      reinterpret_cast<void*>(JITRT_RaytraceAddColoursTupleFloatHelper),
-      instr->output()->type() | TNullptr,
-      instr->arg(0),
-      instr->arg(1),
-      instr->arg(2));
-  return env.emit<CheckExc>(result, *instr->frameState());
-}
-
-static Register* simplifyComprehensionsIsBigSpinnyHelper(
-    Env& env,
-    const CallMethod* instr) {
-  if (!armComprehensionsTinyHelpersEnabled() || instr->NumArgs() != 1) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyCodeObject> enclosing_code{env.func.code};
-  if (!isComprehensionsCode(enclosing_code, "WidgetTray._add_widgets")) {
-    return nullptr;
-  }
-
-  Register* target = modelReg(instr->func());
-  if (!isLoadMethodBase(*target->instr())) {
-    return nullptr;
-  }
-  auto* load_method = static_cast<const LoadMethodBase*>(target->instr());
-  BorrowedRef<PyCodeObject> code = env.func.codeFor(*load_method);
-  if (code == nullptr) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyUnicodeObject> method_name{
-      PyTuple_GET_ITEM(code->co_names, load_method->name_idx())};
-  if (PyUnicode_CompareWithASCIIString(method_name, "_is_big_spinny") != 0) {
-    PyErr_Clear();
-    return nullptr;
-  }
-
-  Ref<> big_kind =
-      getComprehensionsWidgetKindBig(BorrowedRef<PyDictObject>{env.func.globals});
-  if (big_kind == nullptr) {
-    return nullptr;
-  }
-
-  Register* big_kind_const =
-      env.emit<LoadConst>(
-          Type::fromObject(env.func.env.addReference(std::move(big_kind))));
-  Register* result = env.emitVariadic<CallStatic>(
-      2,
-      reinterpret_cast<void*>(JITRT_ComprehensionsIsBigSpinnyHelper),
-      instr->output()->type() | TNullptr,
-      instr->arg(0),
-      big_kind_const);
-  return env.emit<CheckExc>(result, *instr->frameState());
-}
-
-static Register* simplifyComprehensionsAnyKnobbyHelper(
-    Env& env,
-    const CallMethod* instr) {
-  if (!armComprehensionsTinyHelpersEnabled() || instr->NumArgs() != 1) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyCodeObject> enclosing_code{env.func.code};
-  if (!isComprehensionsCode(enclosing_code, "WidgetTray._add_widgets")) {
-    return nullptr;
-  }
-
-  Register* target = modelReg(instr->func());
-  if (!isLoadMethodBase(*target->instr())) {
-    return nullptr;
-  }
-  auto* load_method = static_cast<const LoadMethodBase*>(target->instr());
-  BorrowedRef<PyCodeObject> code = env.func.codeFor(*load_method);
-  if (code == nullptr) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyUnicodeObject> method_name{
-      PyTuple_GET_ITEM(code->co_names, load_method->name_idx())};
-  if (PyUnicode_CompareWithASCIIString(method_name, "_any_knobby") != 0) {
-    PyErr_Clear();
-    return nullptr;
-  }
-
-  Register* result = env.emitVariadic<CallStatic>(
-      1,
-      reinterpret_cast<void*>(JITRT_ComprehensionsAnyKnobbyHelper),
-      instr->output()->type() | TNullptr,
-      instr->arg(0));
-  return env.emit<CheckExc>(result, *instr->frameState());
-}
-
-static Register* simplifyComprehensionsDictGetHelper(
-    Env& env,
-    const CallMethod* instr) {
-  if (!armComprehensionsDictGetHelperEnabled() || instr->NumArgs() != 1) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyCodeObject> enclosing_code{env.func.code};
-  if (!isComprehensionsCode(enclosing_code, "WidgetTray._add_widgets")) {
-    return nullptr;
-  }
-
-  Register* target = modelReg(instr->func());
-  if (!isLoadMethodBase(*target->instr())) {
-    return nullptr;
-  }
-  auto* load_method = static_cast<const LoadMethodBase*>(target->instr());
-  BorrowedRef<PyCodeObject> code = env.func.codeFor(*load_method);
-  if (code == nullptr) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyUnicodeObject> method_name{
-      PyTuple_GET_ITEM(code->co_names, load_method->name_idx())};
-  if (PyUnicode_CompareWithASCIIString(method_name, "get") != 0) {
-    PyErr_Clear();
-    return nullptr;
-  }
-
-  Register* result = env.emitVariadic<CallStatic>(
-      2,
-      reinterpret_cast<void*>(JITRT_ComprehensionsDictGetHelper),
-      instr->output()->type() | TNullptr,
-      instr->self(),
-      instr->arg(0));
-  return env.emit<CheckExc>(result, *instr->frameState());
-}
-
-static Register* simplifyComprehensionsListSortHelper(
-    Env& env,
-    const CallMethod* instr) {
-  if (!armComprehensionsListSortHelperEnabled() || instr->NumArgs() != 0) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyCodeObject> enclosing_code{env.func.code};
-  if (!isComprehensionsCode(enclosing_code, "WidgetTray._add_widgets")) {
-    return nullptr;
-  }
-
-  Register* target = modelReg(instr->func());
-  if (!isLoadMethodBase(*target->instr())) {
-    return nullptr;
-  }
-  auto* load_method = static_cast<const LoadMethodBase*>(target->instr());
-  BorrowedRef<PyCodeObject> code = env.func.codeFor(*load_method);
-  if (code == nullptr) {
-    return nullptr;
-  }
-
-  BorrowedRef<PyUnicodeObject> method_name{
-      PyTuple_GET_ITEM(code->co_names, load_method->name_idx())};
-  if (PyUnicode_CompareWithASCIIString(method_name, "sort") != 0) {
-    PyErr_Clear();
-    return nullptr;
-  }
-
-  Register* result = env.emitVariadic<CallStatic>(
-      1,
-      reinterpret_cast<void*>(JITRT_ComprehensionsListSortHelper),
-      instr->output()->type() | TNullptr,
-      instr->self());
-  return env.emit<CheckExc>(result, *instr->frameState());
-}
-
 static BorrowedRef<PyDictObject> getKnownModuleDict(BorrowedRef<> obj) {
   if (PyModule_Check(obj)) {
     return reinterpret_cast<PyModuleObject*>(obj.get())->md_dict;
@@ -3364,6 +2696,148 @@ static Register* simplifyVectorCallMathSqrt(
   return env.emit<PrimitiveBox>(result, TCDouble, *instr->frameState());
 }
 
+static Register* simplifyVectorCallBuiltinAbs(
+    Env& env,
+    const VectorCall* instr) {
+  if (instr->numArgs() != 1) {
+    return nullptr;
+  }
+
+  Register* target = modelReg(instr->func());
+  bool is_abs = false;
+  if (target->instr()->IsGuardIs()) {
+    auto* guard = static_cast<const GuardIs*>(target->instr());
+    is_abs = isBuiltin(guard->target(), "abs");
+  } else {
+    is_abs = isBuiltin(target, "abs");
+  }
+  if (!is_abs) {
+    return nullptr;
+  }
+
+  Register* arg = instr->arg(0);
+  Register* double_arg = nullptr;
+  if (arg->isA(TCDouble)) {
+    double_arg = arg;
+  } else if (arg->instr()->IsPrimitiveBox()) {
+    auto* box = static_cast<const PrimitiveBox*>(arg->instr());
+    if (box->value()->type() <= TCDouble) {
+      double_arg = box->value();
+    }
+  }
+
+  if (double_arg == nullptr) {
+    if (!arg->isA(TFloatExact)) {
+      arg = env.emit<GuardType>(TFloatExact, arg, *instr->frameState());
+    }
+    double_arg = env.emit<PrimitiveUnbox>(arg, TCDouble);
+  }
+
+  env.emit<UseType>(target, target->type());
+  Register* result = env.emit<DoubleAbs>(double_arg);
+  return env.emit<PrimitiveBox>(result, TCDouble, *instr->frameState());
+}
+
+static Register* emitGenericVectorCallClone(
+    Env& env,
+    const VectorCall* instr) {
+  auto* call = env.emitRawInstr<VectorCall>(
+      instr->NumOperands(),
+      env.func.env.AllocateRegister(),
+      instr->flags() | CallFlags::NoSpecialize,
+      *instr->frameState());
+  for (size_t i = 0; i < instr->NumOperands(); ++i) {
+    call->SetOperand(i, instr->GetOperand(i));
+  }
+  return call->output();
+}
+
+static Register* emitBuiltinMinMaxFloatFastPath(
+    Env& env,
+    Register* target,
+    Register* lhs,
+    Register* rhs,
+    const FrameState& frame,
+    bool is_min) {
+  env.emit<UseType>(target, target->type());
+  env.emit<UseType>(lhs, TFloatExact);
+  env.emit<UseType>(rhs, TFloatExact);
+
+  Register* lhs_unboxed = env.emit<PrimitiveUnbox>(lhs, TCDouble);
+  Register* rhs_unboxed = env.emit<PrimitiveUnbox>(rhs, TCDouble);
+  PrimitiveCompareOp op = is_min ? PrimitiveCompareOp::kLessThanUnsigned
+                                 : PrimitiveCompareOp::kGreaterThanUnsigned;
+  Register* choose_rhs =
+      env.emit<PrimitiveCompare>(op, rhs_unboxed, lhs_unboxed);
+
+  return env.emitCond(
+      [&](BasicBlock* rhs_block, BasicBlock* lhs_block) {
+        env.emit<CondBranch>(choose_rhs, rhs_block, lhs_block);
+      },
+      [&] { // rhs wins
+        env.emit<UseType>(rhs, TFloatExact);
+        return rhs;
+      },
+      [&] { // lhs wins
+        env.emit<UseType>(lhs, TFloatExact);
+        return lhs;
+      });
+}
+
+static Register* emitBuiltinMinMaxTwoArgCheckedFastPath(
+    Env& env,
+    const VectorCall* instr,
+    Register* target,
+    Register* lhs,
+    Register* rhs,
+    bool is_min) {
+  BasicBlock* slow_lhs = env.func.cfg.AllocateBlock();
+  auto* lhs_check =
+      env.emitInstr<CondBranchCheckType>(lhs, TFloatExact, nullptr, slow_lhs);
+  BasicBlock* rhs_check_block = env.func.cfg.splitAfter(*lhs_check);
+  lhs_check->set_true_bb(rhs_check_block);
+
+  env.block = rhs_check_block;
+  env.cursor = rhs_check_block->begin();
+  Register* lhs_float = env.emit<RefineType>(TFloatExact, lhs);
+
+  BasicBlock* slow_rhs = env.func.cfg.AllocateBlock();
+  auto* rhs_check =
+      env.emitInstr<CondBranchCheckType>(rhs, TFloatExact, nullptr, slow_rhs);
+  BasicBlock* fast_block = env.func.cfg.splitAfter(*rhs_check);
+  rhs_check->set_true_bb(fast_block);
+
+  env.block = fast_block;
+  env.cursor = fast_block->begin();
+  Register* rhs_float = env.emit<RefineType>(TFloatExact, rhs);
+  Register* fast_value =
+      emitBuiltinMinMaxFloatFastPath(env, target, lhs_float, rhs_float, *instr->frameState(), is_min);
+
+  auto* fast_exit = env.emitInstr<Branch>(nullptr);
+  BasicBlock* join = env.func.cfg.splitAfter(*fast_exit);
+  fast_exit->set_target(join);
+  BasicBlock* fast_pred = env.block;
+
+  env.block = slow_rhs;
+  env.cursor = slow_rhs->end();
+  Register* rhs_slow_value = emitGenericVectorCallClone(env, instr);
+  env.emit<Branch>(join);
+
+  env.block = slow_lhs;
+  env.cursor = slow_lhs->end();
+  Register* lhs_slow_value = emitGenericVectorCallClone(env, instr);
+  env.emit<Branch>(join);
+
+  env.block = join;
+  env.cursor = join->begin();
+  std::unordered_map<BasicBlock*, Register*> phi_inputs{
+      {fast_pred, fast_value},
+      {slow_rhs, rhs_slow_value},
+      {slow_lhs, lhs_slow_value},
+  };
+  return env.emit<Phi>(phi_inputs);
+}
+
 static Register* simplifyVectorCallBuiltinMinMax(
     Env& env,
     const VectorCall* instr) {
@@ -3441,35 +2915,39 @@ static Register* simplifyVectorCallBuiltinMinMax(
         });
   }
 
-  if (!lhs->isA(TFloatExact)) {
-    lhs = env.emit<GuardType>(TFloatExact, lhs, *instr->frameState());
+  Type lhs_ty = lhs->type();
+  Type rhs_ty = rhs->type();
+
+  // Only consider specialization when both args could actually be boxed exact
+  // floats. This avoids forcing integer-heavy index code and primitive numeric
+  // values through an object-only float path.
+  if (!lhs_ty.couldBe(TObject) || !rhs_ty.couldBe(TObject) ||
+      !lhs_ty.couldBe(TFloatExact) || !rhs_ty.couldBe(TFloatExact)) {
+    return nullptr;
   }
-  if (!rhs->isA(TFloatExact)) {
-    rhs = env.emit<GuardType>(TFloatExact, rhs, *instr->frameState());
+
+  // Leave obviously integral clamp-style shapes on the generic path instead
+  // of forcing them through the float fast path and deopting immediately.
+  if ((lhs->isA(TLongExact) || rhs->isA(TLongExact)) &&
+      !lhs->isA(TFloatExact) && !rhs->isA(TFloatExact)) {
+    return nullptr;
   }
 
-  env.emit<UseType>(target, target->type());
-  env.emit<UseType>(lhs, TFloatExact);
-  env.emit<UseType>(rhs, TFloatExact);
+  auto emit_fast = [&](Register* fast_lhs, Register* fast_rhs) {
+    return emitBuiltinMinMaxFloatFastPath(
+        env, target, fast_lhs, fast_rhs, *instr->frameState(), is_min);
+  };
 
-  Register* lhs_unboxed = env.emit<PrimitiveUnbox>(lhs, TCDouble);
-  Register* rhs_unboxed = env.emit<PrimitiveUnbox>(rhs, TCDouble);
-  PrimitiveCompareOp op = is_min ? PrimitiveCompareOp::kLessThanUnsigned
-                                 : PrimitiveCompareOp::kGreaterThanUnsigned;
-  Register* choose_rhs = env.emit<PrimitiveCompare>(op, rhs_unboxed, lhs_unboxed);
+  if (lhs->isA(TFloatExact) && rhs->isA(TFloatExact)) {
+    return emit_fast(lhs, rhs);
+  }
 
-  return env.emitCond(
-      [&](BasicBlock* rhs_block, BasicBlock* lhs_block) {
-        env.emit<CondBranch>(choose_rhs, rhs_block, lhs_block);
-      },
-      [&] { // rhs wins
-        env.emit<UseType>(rhs, TFloatExact);
-        return rhs;
-      },
-      [&] { // lhs wins
-        env.emit<UseType>(lhs, TFloatExact);
-        return lhs;
-      });
+  if (!lhs->isA(TFloatExact) && !rhs->isA(TFloatExact)) {
+    return emitBuiltinMinMaxTwoArgCheckedFastPath(
+        env, instr, target, lhs, rhs, is_min);
+  }
+
+  return nullptr;
 }
 
 static Register* simplifyLoadModuleAttrCachedMathSqrt(
@@ -3565,21 +3043,6 @@ static Register* resolveArgs(
 
 Register* simplifyCallMethod(Env& env, const CallMethod* instr) {
   if (Register* result = simplifyCallMethodTinyReturnSelf(env, instr)) {
-    return result;
-  }
-  if (Register* result = simplifyComprehensionsIsBigSpinnyHelper(env, instr)) {
-    return result;
-  }
-  if (Register* result = simplifyComprehensionsAnyKnobbyHelper(env, instr)) {
-    return result;
-  }
-  if (Register* result = simplifyComprehensionsDictGetHelper(env, instr)) {
-    return result;
-  }
-  if (Register* result = simplifyComprehensionsListSortHelper(env, instr)) {
-    return result;
-  }
-  if (Register* result = simplifyRaytraceAddColoursTupleFloatHelper(env, instr)) {
     return result;
   }
 
@@ -3779,8 +3242,14 @@ Register* simplifyVectorCall(Env& env, const VectorCall* instr) {
   if (Register* result = simplifyVectorCallStatic(env, instr)) {
     return result;
   }
+  if (instr->flags() & CallFlags::NoSpecialize) {
+    return nullptr;
+  }
   if (instr->flags() & CallFlags::KwArgs) {
     return nullptr;
+  }
+  if (Register* result = simplifyVectorCallBuiltinAbs(env, instr)) {
+    return result;
   }
   if (Register* result = simplifyVectorCallBuiltinMinMax(env, instr)) {
     return result;
@@ -4043,14 +3512,7 @@ Register* simplifyInstr(Env& env, const Instr* instr) {
     case Opcode::kCIntToCBool:
       return simplifyCIntToCBool(env, static_cast<const CIntToCBool*>(instr));
 
-    case Opcode::kYieldFrom:
-      return simplifyYieldFrom(env, static_cast<const YieldFrom*>(instr));
-
     default:
-      // Debug: log if we see YieldFrom in default case
-      if (instr->opcode() == Opcode::kYieldFrom) {
-        JIT_LOG("ERROR: YieldFrom hit default case!");
-      }
       return nullptr;
   }
 }

--- a/cinderx/Jit/jit_rt.cpp
+++ b/cinderx/Jit/jit_rt.cpp
@@ -42,6 +42,7 @@
 #endif
 
 #include <cmath>
+#include <mutex>
 
 // This is mostly taken from ceval.c _PyEval_EvalCodeWithName
 // We use the same logic to turn **args, nargsf, and kwnames into
@@ -928,268 +929,89 @@ PyObject* JITRT_ListSlice(PyObject* list, PyObject* start, PyObject* stop) {
   return PyList_GetSlice(list, start_index, stop_index);
 }
 
-PyObject* JITRT_ListConcat(PyObject* left, PyObject* right) {
-  if (PyList_CheckExact(left) && PyList_CheckExact(right)) {
-    return PyList_Type.tp_as_sequence->sq_concat(left, right);
-  }
-  return PyNumber_Add(left, right);
+#if PY_VERSION_HEX >= 0x030E0000 && PY_VERSION_HEX < 0x030F0000
+
+namespace {
+
+PyObject* get_dict_item_miss_sentinel() {
+  static std::once_flag once;
+  static PyObject* sentinel = nullptr;
+  std::call_once(once, []() {
+    sentinel = PyCapsule_New(
+        reinterpret_cast<void*>(get_dict_item_miss_sentinel),
+        "cinderx.jit.dict_item_miss",
+        nullptr);
+  });
+  return sentinel;
 }
 
-static bool raytraceAddColoursTryUnbox(PyObject* obj, double* out) {
-  if (PyFloat_CheckExact(obj)) {
-    *out = PyFloat_AS_DOUBLE(obj);
-    return true;
-  }
-  if (PyLong_CheckExact(obj)) {
-    double value = PyLong_AsDouble(obj);
-    if (value == -1.0 && PyErr_Occurred()) {
-      return false;
-    }
-    *out = value;
-    return true;
-  }
-  return false;
+} // namespace
+
+PyObject* JITRT_GetDictItemMissSentinel(void) {
+  return get_dict_item_miss_sentinel();
 }
 
-PyObject* JITRT_RaytraceAddColoursTupleFloatHelper(
-    PyObject* left,
-    PyObject* scale,
-    PyObject* right) {
-  if (PyTuple_CheckExact(left) && PyTuple_CheckExact(right) &&
-      PyTuple_GET_SIZE(left) == 3 && PyTuple_GET_SIZE(right) == 3 &&
-      PyFloat_CheckExact(scale)) {
-    double scale_value = PyFloat_AS_DOUBLE(scale);
-    double left_values[3];
-    double right_values[3];
-    for (Py_ssize_t i = 0; i < 3; i++) {
-      if (!raytraceAddColoursTryUnbox(PyTuple_GET_ITEM(left, i), &left_values[i]) ||
-          !raytraceAddColoursTryUnbox(PyTuple_GET_ITEM(right, i), &right_values[i])) {
-        PyErr_Clear();
-        goto generic_fallback;
+PyObject* JITRT_GetDictItemOrSentinel(PyObject* dict, PyObject* key) {
+  JIT_DCHECK(PyDict_CheckExact(dict), "expected exact dict");
+
+  PyObject* value = nullptr;
+  int rc = PyDict_GetItemRef(dict, key, &value);
+  if (rc > 0) {
+    return value;
+  }
+  if (rc == 0) {
+    PyObject* sentinel = get_dict_item_miss_sentinel();
+    return sentinel == nullptr ? nullptr : Py_NewRef(sentinel);
+  }
+  return nullptr;
+}
+
+PyObject* JITRT_DeepcopyTuplePostMiss(PyObject* x, PyObject* y) {
+  if (PyTuple_CheckExact(x) && PyList_CheckExact(y)) {
+    Py_ssize_t size = PyTuple_GET_SIZE(x);
+    if (PyList_GET_SIZE(y) == size) {
+      for (Py_ssize_t i = 0; i < size; ++i) {
+        if (PyTuple_GET_ITEM(x, i) != PyList_GET_ITEM(y, i)) {
+          return PySequence_Tuple(y);
+        }
       }
+      return Py_NewRef(x);
     }
-
-    Ref<> result = Ref<>::steal(PyTuple_New(3));
-    if (result == nullptr) {
-      return nullptr;
-    }
-    for (Py_ssize_t i = 0; i < 3; i++) {
-      PyObject* item =
-          PyFloat_FromDouble(left_values[i] + scale_value * right_values[i]);
-      if (item == nullptr) {
-        return nullptr;
-      }
-      PyTuple_SET_ITEM(result.get(), i, item);
-    }
-    return result.release();
   }
 
-generic_fallback:
-  Ref<> result = Ref<>::steal(PyTuple_New(3));
-  if (result == nullptr) {
+  Ref<> iter_x = Ref<>::steal(PyObject_GetIter(x));
+  if (iter_x == nullptr) {
     return nullptr;
   }
-  for (Py_ssize_t i = 0; i < 3; i++) {
-    Ref<> index = Ref<>::steal(PyLong_FromSsize_t(i));
-    if (index == nullptr) {
-      return nullptr;
-    }
-    Ref<> left_item = Ref<>::steal(PyObject_GetItem(left, index));
-    if (left_item == nullptr) {
-      return nullptr;
-    }
-    Ref<> right_item = Ref<>::steal(PyObject_GetItem(right, index));
-    if (right_item == nullptr) {
-      return nullptr;
-    }
-    Ref<> scaled = Ref<>::steal(PyNumber_Multiply(scale, right_item));
-    if (scaled == nullptr) {
-      return nullptr;
-    }
-    Ref<> summed = Ref<>::steal(PyNumber_Add(left_item, scaled));
-    if (summed == nullptr) {
-      return nullptr;
-    }
-    PyTuple_SET_ITEM(result.get(), i, summed.release());
-  }
-  return result.release();
-}
-
-PyObject* JITRT_ComprehensionsIsBigSpinnyHelper(
-    PyObject* widget,
-    PyObject* big_kind) {
-  Ref<> kind = Ref<>::steal(PyObject_GetAttrString(widget, "kind"));
-  if (kind == nullptr) {
-    return nullptr;
-  }
-  if (kind.get() != big_kind) {
-    Py_RETURN_FALSE;
-  }
-
-  Ref<> has_spinner = Ref<>::steal(PyObject_GetAttrString(widget, "has_spinner"));
-  if (has_spinner == nullptr) {
-    return nullptr;
-  }
-  if (has_spinner == Py_True) {
-    Py_RETURN_TRUE;
-  }
-  if (has_spinner == Py_False) {
-    Py_RETURN_FALSE;
-  }
-
-  int truth = PyObject_IsTrue(has_spinner);
-  if (truth < 0) {
-    return nullptr;
-  }
-  if (truth) {
-    Py_RETURN_TRUE;
-  }
-  Py_RETURN_FALSE;
-}
-
-PyObject* JITRT_ComprehensionsAnyKnobbyHelper(PyObject* widgets) {
-  Ref<> iter = Ref<>::steal(PyObject_GetIter(widgets));
-  if (iter == nullptr) {
+  Ref<> iter_y = Ref<>::steal(PyObject_GetIter(y));
+  if (iter_y == nullptr) {
     return nullptr;
   }
 
   while (true) {
-    Ref<> item = Ref<>::steal(PyIter_Next(iter));
-    if (item == nullptr) {
+    Ref<> item_x = Ref<>::steal(PyIter_Next(iter_x));
+    if (item_x == nullptr) {
       if (PyErr_Occurred()) {
         return nullptr;
       }
-      Py_RETURN_FALSE;
-    }
-    if (item == Py_None) {
-      continue;
+      return Py_NewRef(x);
     }
 
-    int item_truth = PyObject_IsTrue(item);
-    if (item_truth < 0) {
-      return nullptr;
-    }
-    if (!item_truth) {
-      continue;
-    }
-
-    Ref<> has_knob = Ref<>::steal(PyObject_GetAttrString(item, "has_knob"));
-    if (has_knob == nullptr) {
-      return nullptr;
-    }
-    if (has_knob == Py_True) {
-      Py_RETURN_TRUE;
-    }
-    if (has_knob == Py_False) {
-      continue;
+    Ref<> item_y = Ref<>::steal(PyIter_Next(iter_y));
+    if (item_y == nullptr) {
+      if (PyErr_Occurred()) {
+        return nullptr;
+      }
+      return Py_NewRef(x);
     }
 
-    int knob_truth = PyObject_IsTrue(has_knob);
-    if (knob_truth < 0) {
-      return nullptr;
-    }
-    if (knob_truth) {
-      Py_RETURN_TRUE;
+    if (item_x != item_y) {
+      return PySequence_Tuple(y);
     }
   }
 }
 
-PyObject* JITRT_ComprehensionsDictGetHelper(PyObject* dict, PyObject* key) {
-  if (PyDict_CheckExact(dict)) {
-    PyObject* value = PyDict_GetItemWithError(dict, key);
-    if (value != nullptr) {
-      return Py_NewRef(value);
-    }
-    if (PyErr_Occurred()) {
-      return nullptr;
-    }
-    Py_RETURN_NONE;
-  }
-
-  Ref<> name = Ref<>::steal(PyUnicode_FromString("get"));
-  if (name == nullptr) {
-    return nullptr;
-  }
-  return PyObject_CallMethodObjArgs(dict, name, key, nullptr);
-}
-
-namespace {
-
-PyObject* mdpSortedSuccessorItems(PyObject* dist) {
-  Ref<> items = Ref<>::steal(PyMapping_Items(dist));
-  if (items == nullptr) {
-    return nullptr;
-  }
-
-  if (!PyList_CheckExact(items)) {
-    return PySequence_List(items);
-  }
-
-  Py_ssize_t size = PyList_GET_SIZE(items);
-  Ref<> decorated = Ref<>::steal(PyList_New(size));
-  if (decorated == nullptr) {
-    return nullptr;
-  }
-
-  for (Py_ssize_t i = 0; i < size; i++) {
-    PyObject* item = PyList_GET_ITEM(items.get(), i);
-    if (!PyTuple_CheckExact(item) || PyTuple_GET_SIZE(item) != 2) {
-      PyErr_SetString(PyExc_TypeError, "expected (state, prob) tuple");
-      return nullptr;
-    }
-
-    PyObject* state = PyTuple_GET_ITEM(item, 0);
-    PyObject* prob = PyTuple_GET_ITEM(item, 1);
-    Ref<> neg_prob = Ref<>::steal(PyNumber_Negative(prob));
-    if (neg_prob == nullptr) {
-      return nullptr;
-    }
-    Ref<> decorated_item =
-        Ref<>::steal(PyTuple_Pack(3, neg_prob.get(), state, item));
-    if (decorated_item == nullptr) {
-      return nullptr;
-    }
-    PyList_SET_ITEM(decorated.get(), i, decorated_item.release());
-  }
-
-  if (PyList_Sort(decorated) < 0) {
-    return nullptr;
-  }
-
-  Ref<> result = Ref<>::steal(PyList_New(size));
-  if (result == nullptr) {
-    return nullptr;
-  }
-
-  for (Py_ssize_t i = 0; i < size; i++) {
-    PyObject* decorated_item = PyList_GET_ITEM(decorated.get(), i);
-    PyObject* item = PyTuple_GET_ITEM(decorated_item, 2);
-    Py_INCREF(item);
-    PyList_SET_ITEM(result.get(), i, item);
-  }
-
-  return result.release();
-}
-
-} // namespace
-PyObject* JITRT_ComprehensionsListSortHelper(PyObject* list_obj) {
-  if (PyList_CheckExact(list_obj)) {
-    if (PyList_Sort(list_obj) < 0) {
-      return nullptr;
-    }
-    Py_RETURN_NONE;
-  }
-
-  Ref<> name = Ref<>::steal(PyUnicode_FromString("sort"));
-  if (name == nullptr) {
-    return nullptr;
-  }
-  return PyObject_CallMethodObjArgs(list_obj, name, nullptr);
-}
-
-namespace {
-
-} // namespace
+#endif
 
 PyObject* JITRT_LoadFunctionIndirect(PyObject** func, PyObject* descr) {
   PyObject* res = *func;
@@ -1348,6 +1170,15 @@ PyObject* JITRT_Call(
   }
 
   PyThreadState* tstate = _PyThreadState_GET();
+  if (PyFunction_Check(callable)) {
+    auto* func = reinterpret_cast<PyFunctionObject*>(callable);
+    return func->vectorcall(
+        callable,
+        const_cast<PyObject**>(args),
+        nargsf,
+        kwnames);
+  }
+
   PyObject* res =
       _PyObject_VectorcallTstate(tstate, callable, args, nargsf, kwnames);
 #if PY_VERSION_HEX >= 0x030C0000
@@ -1362,18 +1193,91 @@ PyObject* JITRT_Call(
   return res;
 }
 
+PyObject* JITRT_CallMethod(
+    PyObject* callable,
+    PyObject* const* args,
+    size_t nargsf,
+    PyObject* kwnames) {
+  JIT_DCHECK(
+      (nargsf & PY_VECTORCALL_ARGUMENTS_OFFSET),
+      "JITRT_CallMethod must always be called as a vectorcall");
+
+  // CallMethod always passes self-or-null in args[0].
+  if constexpr (PY_VERSION_HEX >= 0x030E0000) {
+    if (args[0] == nullptr) {
+      args += 1;
+      nargsf -= 1;
+    }
+  }
+
+  PyThreadState* tstate = _PyThreadState_GET();
+
+  if (PyFunction_Check(callable)) {
+    auto* func = reinterpret_cast<PyFunctionObject*>(callable);
+    return func->vectorcall(
+        callable,
+        const_cast<PyObject**>(args),
+        nargsf,
+        kwnames);
+  }
+
+  PyObject* res =
+      _PyObject_VectorcallTstate(tstate, callable, args, nargsf, kwnames);
+#if PY_VERSION_HEX >= 0x030C0000
+  if (handle_periodic_activities_on_call(tstate, res, callable)) {
+    Py_DECREF(res);
+    return nullptr;
+  }
+#endif
+  return res;
+}
+
 PyObject* JITRT_Vectorcall(
     PyObject* callable,
     PyObject* const* args,
     size_t nargsf,
     PyObject* kwnames) {
   PyThreadState* tstate = _PyThreadState_GET();
+  if (PyFunction_Check(callable)) {
+    auto* func = reinterpret_cast<PyFunctionObject*>(callable);
+    return func->vectorcall(
+        callable,
+        const_cast<PyObject**>(args),
+        nargsf,
+        kwnames);
+  }
+
   PyObject* res =
       _PyObject_VectorcallTstate(tstate, callable, args, nargsf, kwnames);
 #if PY_VERSION_HEX >= 0x030C0000
   // In 3.12 calls to non-Python functions will check for the eval breaker
   // We handle that here rather than bloat every function call w/ an extra
   // check.
+  if (handle_periodic_activities_on_call(tstate, res, callable)) {
+    Py_DECREF(res);
+    return nullptr;
+  }
+#endif
+  return res;
+}
+
+PyObject* JITRT_CallMethodDescrFast1(
+    PyObject* callable,
+    PyObject* self,
+    PyObject* arg0) {
+  JIT_DCHECK(
+      Py_IS_TYPE(callable, &PyMethodDescr_Type),
+      "expected method descriptor");
+  auto* method = reinterpret_cast<PyMethodDescrObject*>(callable);
+  JIT_DCHECK(
+      method->d_method->ml_flags == METH_FASTCALL,
+      "expected METH_FASTCALL descriptor");
+
+  PyObject* args[1] = {arg0};
+  auto cfunc = _PyCFunctionFast_CAST(method->d_method->ml_meth);
+  PyObject* res = cfunc(self, args, /*nargs=*/1);
+#if PY_VERSION_HEX >= 0x030C0000
+  PyThreadState* tstate = _PyThreadState_GET();
   if (handle_periodic_activities_on_call(tstate, res, callable)) {
     Py_DECREF(res);
     return nullptr;

--- a/cinderx/PythonLib/test_cinderx/test_jit_mdp_apply_hp_change_experiments.py
+++ b/cinderx/PythonLib/test_cinderx/test_jit_mdp_apply_hp_change_experiments.py
@@ -74,12 +74,14 @@ class MdpApplyHpChangeExperimentTests(unittest.TestCase):
             with open(script, "w", encoding="utf-8") as fp:
                 fp.write(code)
 
+            env_baseline = dict(os.environ)
+            env_baseline["PYTHONJIT_ARM_MDP_INT_CLAMP_MIN_MAX"] = "0"
             proc_baseline = subprocess.run(
                 [sys.executable, script],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                env=dict(os.environ),
+                env=env_baseline,
             )
             self.assertEqual(
                 proc_baseline.returncode,
@@ -87,25 +89,23 @@ class MdpApplyHpChangeExperimentTests(unittest.TestCase):
                 f"stdout:\n{proc_baseline.stdout}\nstderr:\n{proc_baseline.stderr}",
             )
 
-            env_optimized = dict(os.environ)
-            env_optimized["PYTHONJIT_ARM_MDP_INT_CLAMP_MIN_MAX"] = "1"
-            proc_optimized = subprocess.run(
+            proc_default = subprocess.run(
                 [sys.executable, script],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                env=env_optimized,
+                env=dict(os.environ),
             )
             self.assertEqual(
-                proc_optimized.returncode,
+                proc_default.returncode,
                 0,
-                f"stdout:\n{proc_optimized.stdout}\nstderr:\n{proc_optimized.stderr}",
+                f"stdout:\n{proc_default.stdout}\nstderr:\n{proc_default.stderr}",
             )
 
             baseline = [int(part) for part in proc_baseline.stdout.split()]
-            optimized = [int(part) for part in proc_optimized.stdout.split()]
+            optimized = [int(part) for part in proc_default.stdout.split()]
             self.assertEqual(len(baseline), 4, proc_baseline.stdout)
-            self.assertEqual(len(optimized), 4, proc_optimized.stdout)
+            self.assertEqual(len(optimized), 4, proc_default.stdout)
 
             b_guard_type, b_compare_bool, b_deopt, b_total = baseline
             o_guard_type, o_compare_bool, o_deopt, o_total = optimized
@@ -113,6 +113,6 @@ class MdpApplyHpChangeExperimentTests(unittest.TestCase):
             self.assertGreater(b_guard_type, 0, proc_baseline.stdout)
             self.assertEqual(b_compare_bool, 0, proc_baseline.stdout)
             self.assertGreater(b_deopt, 0, proc_baseline.stdout)
-            self.assertEqual(b_total, o_total, (proc_baseline.stdout, proc_optimized.stdout))
-            self.assertGreaterEqual(o_compare_bool, 1, proc_optimized.stdout)
-            self.assertLess(o_deopt, b_deopt, (proc_baseline.stdout, proc_optimized.stdout))
+            self.assertEqual(b_total, o_total, (proc_baseline.stdout, proc_default.stdout))
+            self.assertGreaterEqual(o_compare_bool, 1, proc_default.stdout)
+            self.assertLess(o_deopt, b_deopt, (proc_baseline.stdout, proc_default.stdout))

--- a/cinderx/PythonLib/test_cinderx/test_jit_mdp_get_crit_dist_experiments.py
+++ b/cinderx/PythonLib/test_cinderx/test_jit_mdp_get_crit_dist_experiments.py
@@ -64,12 +64,14 @@ class MdpGetCritDistExperimentTests(unittest.TestCase):
             with open(script, "w", encoding="utf-8") as fp:
                 fp.write(code)
 
+            env_baseline = dict(os.environ)
+            env_baseline["PYTHONJIT_ARM_MDP_FRACTION_MIN_COMPARE"] = "0"
             proc_baseline = subprocess.run(
                 [sys.executable, script],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                env=dict(os.environ),
+                env=env_baseline,
             )
             self.assertEqual(
                 proc_baseline.returncode,
@@ -77,29 +79,27 @@ class MdpGetCritDistExperimentTests(unittest.TestCase):
                 f"stdout:\n{proc_baseline.stdout}\nstderr:\n{proc_baseline.stderr}",
             )
 
-            env_optimized = dict(os.environ)
-            env_optimized["PYTHONJIT_ARM_MDP_FRACTION_MIN_COMPARE"] = "1"
-            proc_optimized = subprocess.run(
+            proc_default = subprocess.run(
                 [sys.executable, script],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                env=env_optimized,
+                env=dict(os.environ),
             )
             self.assertEqual(
-                proc_optimized.returncode,
+                proc_default.returncode,
                 0,
-                f"stdout:\n{proc_optimized.stdout}\nstderr:\n{proc_optimized.stderr}",
+                f"stdout:\n{proc_default.stdout}\nstderr:\n{proc_default.stderr}",
             )
 
             baseline = [
                 line.strip() for line in proc_baseline.stdout.splitlines() if line.strip()
             ]
             optimized = [
-                line.strip() for line in proc_optimized.stdout.splitlines() if line.strip()
+                line.strip() for line in proc_default.stdout.splitlines() if line.strip()
             ]
             self.assertEqual(len(baseline), 5, proc_baseline.stdout)
-            self.assertEqual(len(optimized), 5, proc_optimized.stdout)
+            self.assertEqual(len(optimized), 5, proc_default.stdout)
 
             b_guard_type = int(baseline[0])
             b_compare_bool = int(baseline[1])
@@ -116,7 +116,7 @@ class MdpGetCritDistExperimentTests(unittest.TestCase):
             self.assertGreater(b_guard_type, 0, proc_baseline.stdout)
             self.assertEqual(b_compare_bool, 0, proc_baseline.stdout)
             self.assertGreater(b_deopt, 0, proc_baseline.stdout)
-            self.assertEqual(b_summary, o_summary, (proc_baseline.stdout, proc_optimized.stdout))
-            self.assertEqual(b_total, o_total, (proc_baseline.stdout, proc_optimized.stdout))
-            self.assertGreaterEqual(o_compare_bool, 1, proc_optimized.stdout)
-            self.assertLess(o_deopt, b_deopt, (proc_baseline.stdout, proc_optimized.stdout))
+            self.assertEqual(b_summary, o_summary, (proc_baseline.stdout, proc_default.stdout))
+            self.assertEqual(b_total, o_total, (proc_baseline.stdout, proc_default.stdout))
+            self.assertGreaterEqual(o_compare_bool, 1, proc_default.stdout)
+            self.assertLess(o_deopt, b_deopt, (proc_baseline.stdout, proc_default.stdout))

--- a/cinderx/PythonLib/test_cinderx/test_jit_mdp_get_successors_b_experiments.py
+++ b/cinderx/PythonLib/test_cinderx/test_jit_mdp_get_successors_b_experiments.py
@@ -72,12 +72,14 @@ class MdpGetSuccessorsBExperimentTests(unittest.TestCase):
             with open(script, "w", encoding="utf-8") as fp:
                 fp.write(code)
 
+            env_baseline = dict(os.environ)
+            env_baseline["PYTHONJIT_ARM_MDP_PRIORITY_COMPARE_ADD"] = "0"
             proc_baseline = subprocess.run(
                 [sys.executable, script],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                env=dict(os.environ),
+                env=env_baseline,
             )
             self.assertEqual(
                 proc_baseline.returncode,
@@ -85,29 +87,27 @@ class MdpGetSuccessorsBExperimentTests(unittest.TestCase):
                 f"stdout:\n{proc_baseline.stdout}\nstderr:\n{proc_baseline.stderr}",
             )
 
-            env_optimized = dict(os.environ)
-            env_optimized["PYTHONJIT_ARM_MDP_PRIORITY_COMPARE_ADD"] = "1"
-            proc_optimized = subprocess.run(
+            proc_default = subprocess.run(
                 [sys.executable, script],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                env=env_optimized,
+                env=dict(os.environ),
             )
             self.assertEqual(
-                proc_optimized.returncode,
+                proc_default.returncode,
                 0,
-                f"stdout:\n{proc_optimized.stdout}\nstderr:\n{proc_optimized.stderr}",
+                f"stdout:\n{proc_default.stdout}\nstderr:\n{proc_default.stderr}",
             )
 
             baseline = [
                 line.strip() for line in proc_baseline.stdout.splitlines() if line.strip()
             ]
             optimized = [
-                line.strip() for line in proc_optimized.stdout.splitlines() if line.strip()
+                line.strip() for line in proc_default.stdout.splitlines() if line.strip()
             ]
             self.assertEqual(len(baseline), 3, proc_baseline.stdout)
-            self.assertEqual(len(optimized), 3, proc_optimized.stdout)
+            self.assertEqual(len(optimized), 3, proc_default.stdout)
 
             b_binary_op = int(baseline[0])
             b_long_binary_op = int(baseline[1])
@@ -117,10 +117,10 @@ class MdpGetSuccessorsBExperimentTests(unittest.TestCase):
             o_long_binary_op = int(optimized[1])
             o_summary = optimized[2]
 
-            self.assertEqual(b_summary, o_summary, (proc_baseline.stdout, proc_optimized.stdout))
-            self.assertLess(o_binary_op, b_binary_op, (proc_baseline.stdout, proc_optimized.stdout))
+            self.assertEqual(b_summary, o_summary, (proc_baseline.stdout, proc_default.stdout))
+            self.assertLess(o_binary_op, b_binary_op, (proc_baseline.stdout, proc_default.stdout))
             self.assertGreaterEqual(
                 o_long_binary_op,
                 b_long_binary_op,
-                (proc_baseline.stdout, proc_optimized.stdout),
+                (proc_baseline.stdout, proc_default.stdout),
             )


### PR DESCRIPTION
## 摘要

这个 PR 修正上一个 `mdp` 优化 PR 中误带的非 `mdp` 代码变更。

保留内容：
- `applyHPChange` 的整数 `min/max` 优化
- `getCritDist` 的 `Fraction min` 比较优化
- `Battle._getSuccessorsB` 的 priority compare-add 优化
- 上述 3 个 `mdp` 开关默认启用，显式设为 `0` 时关闭

回退内容：
- `simplify.cpp` 中与 `mdp` 无关的实验/优化逻辑
- `jit_rt.cpp` 中与 `mdp` 无关的 helper 变更

## 背景

之前合入的 `mdp` PR 在整理 `simplify.cpp` / `jit_rt.cpp` 时误带入了其它本地实验改动，导致改动范围超出 `mdp` 优化本身，并引入了编译问题。

这个 PR 的目标是把范围收回到 `mdp` 实际需要的最小集合，只保留确认有效的 3 个优化点。

## 保留的 mdp 优化点

1. `applyHPChange`
   - 对整数 `min/max` 路径做窄专门化

2. `getCritDist`
   - 对 `Fraction` 驱动的 `min` 比较路径做窄专门化

3. `Battle._getSuccessorsB`
   - 对 `10000 * (action == "...")` 的 priority bonus 形状做窄专门化

## 验证

已完成以下验证：

- `CMAKE_BUILD_TYPE=Debug ... setup.py build_ext --inplace`
- `test_jit_mdp_apply_hp_change_experiments`
- `test_jit_mdp_get_crit_dist_experiments`
- `test_jit_mdp_get_successors_b_experiments`

