### PR TITLE
(nbody) support 3.14 BINARY_OP_SUBSCR specialized opcodes

### DIFF
--- a/cinderx/Jit/bytecode.cpp
+++ b/cinderx/Jit/bytecode.cpp
@@ -85,6 +85,11 @@ int BytecodeInstruction::specializedOpcode() const {
     case BINARY_SUBSCR_DICT:
     case BINARY_SUBSCR_LIST_INT:
     case BINARY_SUBSCR_TUPLE_INT:
+#if PY_VERSION_HEX >= 0x030E0000
+    case BINARY_OP_SUBSCR_DICT:
+    case BINARY_OP_SUBSCR_LIST_INT:
+    case BINARY_OP_SUBSCR_TUPLE_INT:
+#endif
     case COMPARE_OP_FLOAT:
     case COMPARE_OP_INT:
     case COMPARE_OP_STR:

--- a/cinderx/Jit/hir/builder.cpp
+++ b/cinderx/Jit/hir/builder.cpp
@@ -3338,7 +3338,13 @@ bool HIRBuilder::tryEmitDeepcopyDictSubscrRewrite(
     return false;
   }
 
-  if (bc_instr.specializedOpcode() != BINARY_SUBSCR_DICT) {
+  bool is_dict_subscr_specialized =
+#if PY_VERSION_HEX >= 0x030E0000
+      bc_instr.specializedOpcode() == BINARY_OP_SUBSCR_DICT;
+#else
+      bc_instr.specializedOpcode() == BINARY_SUBSCR_DICT;
+#endif
+  if (!is_dict_subscr_specialized) {
     tc.emit<GuardType>(container, TDictExact, container, tc.frame);
   }
 
@@ -3628,13 +3634,22 @@ void HIRBuilder::emitBinaryOp(
         tc.emit<GuardType>(right, TUnicodeExact, right, tc.frame);
         break;
       case BINARY_SUBSCR_DICT:
+#if PY_VERSION_HEX >= 0x030E0000
+      case BINARY_OP_SUBSCR_DICT:
+#endif
         tc.emit<GuardType>(left, TDictExact, left, tc.frame);
         break;
       case BINARY_SUBSCR_LIST_INT:
+#if PY_VERSION_HEX >= 0x030E0000
+      case BINARY_OP_SUBSCR_LIST_INT:
+#endif
         tc.emit<GuardType>(left, TListExact, left, tc.frame);
         tc.emit<GuardType>(right, TLongExact, right, tc.frame);
         break;
       case BINARY_SUBSCR_TUPLE_INT:
+#if PY_VERSION_HEX >= 0x030E0000
+      case BINARY_OP_SUBSCR_TUPLE_INT:
+#endif
         tc.emit<GuardType>(left, TTupleExact, left, tc.frame);
         tc.emit<GuardType>(right, TLongExact, right, tc.frame);
         break;


### PR DESCRIPTION
## 优化内容

这次优化把 Cpython 3.14 的下标特化 opcode 正式接入了 CInderx JIT, 避免因 opcode 改名导致的特化丢失
1. 在 `BytecodeInstruction::sepcializedOpcode()` 中加入 3.14 新 opcode 白名单：
- BINARY_OP_SUBSCR_DICT:
- BINARY_OP_SUBSCR_LIST_INT:
- BINARY_OP_SUBSCR_TUPLE_INT:
2. 在 HIR builder 中让新旧 opcode 都能命中相同的 fast path:
- `emitBinaryOp()` 中的dict/list/tuple 下标 guard 分支新增 `BINARY_OP_SUBSCR_*`
## 性能效果
```
+---------------------+------------------------------+------------------------------+
| Benchmark           | cinderx-d88de0b3-0324-200744 | cinderx-bf077311-0324-204353 |
+=====================+==============================+==============================+
| nbody               | 56.0 ms                      | 51.8 ms: 1.08x faster        |
+---------------------+------------------------------+------------------------------+
| fannkuch            | 267 ms                       | 260 ms: 1.03x faster         |
+---------------------+------------------------------+------------------------------+
| mdp                 | 1.31 sec                     | 1.28 sec: 1.02x faster       |
+---------------------+------------------------------+------------------------------+
| unpack_sequence     | 3.80 ns                      | 3.73 ns: 1.02x faster        |
+---------------------+------------------------------+------------------------------+
| coroutines          | 31.8 ms                      | 31.3 ms: 1.02x faster        |
+---------------------+------------------------------+------------------------------+
| comprehensions      | 22.1 us                      | 22.0 us: 1.00x faster        |
+---------------------+------------------------------+------------------------------+
| scimark_lu          | 61.4 ms                      | 61.2 ms: 1.00x faster        |
+---------------------+------------------------------+------------------------------+
| deepcopy_reduce     | 2.18 us                      | 2.17 us: 1.00x faster        |
+---------------------+------------------------------+------------------------------+
| raytrace            | 271 ms                       | 271 ms: 1.00x faster         |
+---------------------+------------------------------+------------------------------+
| coverage            | 5.53 ms                      | 5.53 ms: 1.00x slower        |
+---------------------+------------------------------+------------------------------+
| go                  | 114 ms                       | 115 ms: 1.00x slower         |
+---------------------+------------------------------+------------------------------+
| scimark_sor         | 97.0 ms                      | 97.4 ms: 1.00x slower        |
+---------------------+------------------------------+------------------------------+
| scimark_monte_carlo | 52.1 ms                      | 52.3 ms: 1.00x slower        |
+---------------------+------------------------------+------------------------------+
| deepcopy            | 211 us                       | 212 us: 1.00x slower         |
+---------------------+------------------------------+------------------------------+
| nqueens             | 56.8 ms                      | 57.2 ms: 1.01x slower        |
+---------------------+------------------------------+------------------------------+
| richards_super      | 41.2 ms                      | 41.5 ms: 1.01x slower        |
+---------------------+------------------------------+------------------------------+
| chaos               | 41.7 ms                      | 42.3 ms: 1.01x slower        |
+---------------------+------------------------------+------------------------------+
| deepcopy_memo       | 24.0 us                      | 24.3 us: 1.02x slower        |
+---------------------+------------------------------+------------------------------+
| Geometric mean      | (ref)                        | 1.00x faster                 |
+---------------------+------------------------------+------------------------------+

Benchmark hidden because not significant (8): scimark_fft, scimark_sparse_mat_mult, tomli_loads, deltablue, richards, float, spectral_norm, generators
```