### PR TITLE
优化getInterpretedVectorcall

### DIFF
--- a/cinderx/Interpreter/interpreter_base.cpp
+++ b/cinderx/Interpreter/interpreter_base.cpp
@@ -13,18 +13,24 @@
 #endif
 
 extern "C" {
-
-vectorcallfunc getInterpretedVectorcall(
-    [[maybe_unused]] const PyFunctionObject* func) {
+#ifdef CINDER_ENABLE_STATIC_PYTHON
+  vectorcallfunc getInterpretedVectorcall(
+      [[maybe_unused]] const PyFunctionObject* func) {
 #ifdef ENABLE_INTERPRETER_LOOP
-  const PyCodeObject* code = (const PyCodeObject*)(func->func_code);
-  return (code->co_flags & CI_CO_STATICALLY_COMPILED)
-      ? Ci_StaticFunction_Vectorcall
-      : Ci_PyFunction_Vectorcall;
+    const PyCodeObject* code = (const PyCodeObject*)(func->func_code);
+    return (code->co_flags & CI_CO_STATICALLY_COMPILED)
+        ? Ci_StaticFunction_Vectorcall
+        : Ci_PyFunction_Vectorcall;
 #else
-  return Ci_PyFunction_Vectorcall;
+    return Ci_PyFunction_Vectorcall;
 #endif
-}
+  }
+#else
+  vectorcallfunc getInterpretedVectorcall(
+      [[maybe_unused]] const PyFunctionObject* func) {
+    return Ci_PyFunction_Vectorcall;
+  }
+#endif
 
 int Ci_InitFrameEvalFunc() {
 #ifdef ENABLE_INTERPRETER_LOOP


### PR DESCRIPTION
### 改动内容
- 使用 #ifdef CINDER_ENABLE_STATIC_PYTHON 宏隔离 getInterpretedVectorcall 函数
- 当 CINDER_ENABLE_STATIC_PYTHON 启用时：保留原有逻辑，检查 CI_CO_STATICALLY_COMPILED 标志选择对应的 vectorcall
- 当 CINDER_ENABLE_STATIC_PYTHON 禁用时：直接返回 Ci_PyFunction_Vectorcall ，跳过静态函数分支
### 效果
<img width="1218" height="522" alt="image" src="https://github.com/user-attachments/assets/590ca6c6-5329-42ee-8d3d-4812cb901224" />

