### PR TITLE
jit: add 3.14 TO_BOOL specialization and branch fastpath

### DIFF
--- a/cinderx/Jit/bytecode.cpp
+++ b/cinderx/Jit/bytecode.cpp
@@ -98,6 +98,13 @@ int BytecodeInstruction::specializedOpcode() const {
     case CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS:
     case CALL_METHOD_DESCRIPTOR_NOARGS:
     case CALL_METHOD_DESCRIPTOR_O:
+#if PY_VERSION_HEX >= 0x030E0000
+    case TO_BOOL_BOOL:
+    case TO_BOOL_INT:
+    case TO_BOOL_LIST:
+    case TO_BOOL_NONE:
+    case TO_BOOL_STR:
+#endif
     case LOAD_ATTR_INSTANCE_VALUE:
     case LOAD_ATTR_METHOD_WITH_VALUES:
     case LOAD_ATTR_SLOT:

--- a/cinderx/Jit/hir/builder.cpp
+++ b/cinderx/Jit/hir/builder.cpp
@@ -1730,7 +1730,7 @@ void HIRBuilder::translate(
           break;
         }
         case TO_BOOL: {
-          emitToBool(tc);
+          emitToBool(tc, &bc_instr);
           break;
         }
         case COPY_DICT_WITHOUT_KEYS: {
@@ -4416,8 +4416,40 @@ void HIRBuilder::emitCompareOp(
   }
 }
 
-void HIRBuilder::emitToBool(TranslationContext& tc) {
+void HIRBuilder::emitToBool(
+    TranslationContext& tc,
+    const jit::BytecodeInstruction* bc_instr) {
   Register* operand = tc.frame.stack.pop();
+
+  if (bc_instr != nullptr && getConfig().specialized_opcodes) {
+    switch (bc_instr->specializedOpcode()) {
+#if PY_VERSION_HEX >= 0x030E0000
+      case TO_BOOL_NONE: {
+        tc.emit<GuardType>(operand, TNoneType, operand, tc.frame);
+        Register* false_obj = temps_.AllocateStack();
+        tc.emit<LoadConst>(false_obj, Type::fromObject(Py_False));
+        tc.frame.stack.push(false_obj);
+        return;
+      }
+      case TO_BOOL_BOOL:
+        tc.emit<GuardType>(operand, TBool, operand, tc.frame);
+        tc.frame.stack.push(operand);
+        return;
+      case TO_BOOL_INT:
+        tc.emit<GuardType>(operand, TLongExact, operand, tc.frame);
+        break;
+      case TO_BOOL_LIST:
+        tc.emit<GuardType>(operand, TListExact, operand, tc.frame);
+        break;
+      case TO_BOOL_STR:
+        tc.emit<GuardType>(operand, TUnicodeExact, operand, tc.frame);
+        break;
+#endif
+      default:
+        break;
+    }
+  }
+
   Register* truthy_result = temps_.AllocateStack();
   tc.emit<IsTruthy>(truthy_result, operand, tc.frame);
 
@@ -4482,6 +4514,11 @@ void HIRBuilder::emitJumpIf(
   BasicBlock* false_block = getBlockAtOff(false_offset);
 
   if (check_truthy) {
+    if (var->instr()->IsPrimitiveBoxBool()) {
+      tc.emit<CondBranch>(var->instr()->GetOperand(0), true_block, false_block);
+      return;
+    }
+
     Register* tval = temps_.AllocateNonStack();
     // Registers that hold the result of `IsTruthy` are guaranteed to never be
     // the home of a value left on the stack at the end of a basic block, so we
@@ -5774,6 +5811,13 @@ void HIRBuilder::emitPopJumpIf(
 
   if (bc_instr.opcode() == POP_JUMP_IF_FALSE ||
       bc_instr.opcode() == POP_JUMP_IF_TRUE) {
+    if constexpr (PY_VERSION_HEX >= 0x030E0000) {
+      if (var->instr()->IsPrimitiveBoxBool()) {
+        tc.emit<CondBranch>(var->instr()->GetOperand(0), true_block, false_block);
+        return;
+      }
+    }
+
     Register* is_true = temps_.AllocateNonStack();
     // In 3.14+ coercion to exactly Py_True or Py_False is performed by earlier
     // instructions. See GH-106008.

--- a/cinderx/Jit/hir/builder.h
+++ b/cinderx/Jit/hir/builder.h
@@ -194,7 +194,9 @@ class HIRBuilder {
   void emitCompareOp(
       TranslationContext& tc,
       const jit::BytecodeInstruction& bc_instr);
-  void emitToBool(TranslationContext& tc);
+  void emitToBool(
+      TranslationContext& tc,
+      const jit::BytecodeInstruction* bc_instr = nullptr);
   void emitCopyDictWithoutKeys(TranslationContext& tc);
   void emitGetLen(TranslationContext& tc);
   void emitJumpIf(

--- a/cinderx/PythonLib/test_cinderx/test_jit_specialization.py
+++ b/cinderx/PythonLib/test_cinderx/test_jit_specialization.py
@@ -260,3 +260,29 @@ class SpecializationTests(unittest.TestCase):
         self.assertNotIn("UNPACK_SEQUENCE", opnames(f))
         self.assertIn("UNPACK_SEQUENCE_TWO_TUPLE", opnames(f))
         self.assertEqual(f(("c", "d")), "c")
+
+    @passIf(sys.version_info < (3, 14), "Requires Python 3.14 TO_BOOL specialization")
+    def test_to_bool_int(self) -> None:
+        def f(x: int) -> int:
+            if x:
+                return 1
+            return 0
+
+        specialize(f, lambda: f(1))
+
+        self.assertIn("TO_BOOL_INT", opnames(f))
+        self.assertEqual(f(1), 1)
+        self.assertEqual(f(0), 0)
+
+    @passIf(sys.version_info < (3, 14), "Requires Python 3.14 TO_BOOL specialization")
+    def test_to_bool_list(self) -> None:
+        def f(li: list[int]) -> int:
+            if li:
+                return 1
+            return 0
+
+        specialize(f, lambda: f([1]))
+
+        self.assertIn("TO_BOOL_LIST", opnames(f))
+        self.assertEqual(f([1]), 1)
+        self.assertEqual(f([]), 0)


### PR DESCRIPTION
## 概述

本 PR 为 CinderX JIT 添加了 Python 3.14 中 `TO_BOOL` 指令的特化（specialization）支持，并引入了条件分支的快速路径优化。

**主要改动：**

**1. 识别特化操作码（bytecode.cpp）**
在 `specializedOpcode()` 中注册了 5 个 3.14 新增的特化操作码：`TO_BOOL_BOOL`、`TO_BOOL_INT`、`TO_BOOL_LIST`、`TO_BOOL_NONE`、`TO_BOOL_STR`，均通过 `PY_VERSION_HEX >= 0x030E0000` 版本守卫。

**2. HIR 层特化翻译（builder.cpp - emitToBool）**
根据不同的特化类型生成更精确的 HIR：
- `TO_BOOL_NONE`：插入 `GuardType(TNoneType)` 后直接加载 `Py_False`，完全跳过 `IsTruthy` 调用。
- `TO_BOOL_BOOL`：插入 `GuardType(TBool)` 后直接复用原操作数，跳过 `IsTruthy`。
- `TO_BOOL_INT` / `TO_BOOL_LIST` / `TO_BOOL_STR`：插入对应精确类型的 `GuardType`，仍走 `IsTruthy`，但类型收窄后有利于后续优化。

**3. 条件分支快速路径（builder.cpp - emitJumpIf / emitPopJumpIf）**
当分支条件的值来源于 `PrimitiveBoxBool`（即已知是装箱的原始布尔值）时，直接对底层原始布尔操作数发射 `CondBranch`，避免了冗余的 `IsTruthy` 检查。这与 `TO_BOOL_BOOL` / `TO_BOOL_NONE` 特化配合，使 `if x:` 这类模式在已知类型时能生成更高效的代码。

**4. 测试（test_jit_specialization.py）**
新增 `test_to_bool_int` 和 `test_to_bool_list` 两个测试用例，验证特化操作码被正确识别和执行。

## 实测性能
```
All benchmarks:
===============

+---------------------+------------------------------+------------------------------+
| Benchmark           | cinderx-cc95f63e-0325-234223 | cinderx-60e7f342-0325-235732 |
+=====================+==============================+==============================+
| go                  | 114 ms                       | 56.8 ms: 2.01x faster        |
+---------------------+------------------------------+------------------------------+
| fannkuch            | 261 ms                       | 255 ms: 1.02x faster         |
+---------------------+------------------------------+------------------------------+
| richards            | 36.7 ms                      | 35.9 ms: 1.02x faster        |
+---------------------+------------------------------+------------------------------+
| richards_super      | 41.5 ms                      | 40.7 ms: 1.02x faster        |
+---------------------+------------------------------+------------------------------+
| deepcopy_memo       | 24.2 us                      | 24.0 us: 1.01x faster        |
+---------------------+------------------------------+------------------------------+
| hexiom              | 4.80 ms                      | 4.76 ms: 1.01x faster        |
+---------------------+------------------------------+------------------------------+
| scimark_sor         | 97.6 ms                      | 96.9 ms: 1.01x faster        |
+---------------------+------------------------------+------------------------------+
| tomli_loads         | 1.97 sec                     | 1.96 sec: 1.01x faster       |
+---------------------+------------------------------+------------------------------+
| coroutines          | 31.9 ms                      | 31.7 ms: 1.01x faster        |
+---------------------+------------------------------+------------------------------+
| comprehensions      | 12.3 us                      | 12.2 us: 1.01x faster        |
+---------------------+------------------------------+------------------------------+
| deltablue           | 3.79 ms                      | 3.77 ms: 1.01x faster        |
+---------------------+------------------------------+------------------------------+
| scimark_lu          | 60.9 ms                      | 60.6 ms: 1.00x faster        |
+---------------------+------------------------------+------------------------------+
| scimark_monte_carlo | 51.1 ms                      | 51.1 ms: 1.00x faster        |
+---------------------+------------------------------+------------------------------+
| scimark_fft         | 121 ms                       | 121 ms: 1.00x slower         |
+---------------------+------------------------------+------------------------------+
| chaos               | 41.9 ms                      | 42.1 ms: 1.01x slower        |
+---------------------+------------------------------+------------------------------+
| deepcopy_reduce     | 2.15 us                      | 2.16 us: 1.01x slower        |
+---------------------+------------------------------+------------------------------+
| raytrace            | 267 ms                       | 269 ms: 1.01x slower         |
+---------------------+------------------------------+------------------------------+
| nqueens             | 57.6 ms                      | 58.2 ms: 1.01x slower        |
+---------------------+------------------------------+------------------------------+
| generators          | 56.8 ms                      | 57.4 ms: 1.01x slower        |
+---------------------+------------------------------+------------------------------+
| Geometric mean      | (ref)                        | 1.03x faster                 |
+---------------------+------------------------------+------------------------------+
```

**go用例性能提升明显**
**commit^（优化前）：**
```
bb 12 (preds 10, 11) {
    v142:Object = Phi<10, 11> v132 v140
    v147:CBool = IsTruthy v142                    ← 泛型真值判断
    Decref v142
    CondBranch<3, 4> v147
}
```

**commit（优化后）：**
```
bb 12 (preds 10, 11) {
    v137:Object = Phi<10, 11> v127 v135
    v143:ImmortalBool[True] = LoadConst<ImmortalBool[True]>
    v144:CBool = PrimitiveCompare<Equal> v137 v143  ← 直接与 True 单例比较
    Decref v137
    CondBranch<3, 4> v144
}
```
`IsTruthy` 在运行时需要：加载对象的 `ob_type`，查找 `tp_as_number->nb_bool` 槽位，通过函数指针调用 `bool_bool()`（虽然对 `bool` 类型来说只是返回底层 C int，但调度开销仍在）。替换为 `PrimitiveCompare<Equal>` 后变成一条直接的指针比较——因为 CPython 中 `True` 和 `False` 都是全局单例（immortal），判断 `obj == Py_True` 就是一次地址比较，零间接调用开销。