### PR TITLE
JIT：增强列表反向切片赋值模式的专用 lowering（默认开启）

### DIFF
--- a/cinderx/Jit/hir/simplify.cpp
+++ b/cinderx/Jit/hir/simplify.cpp
@@ -12,6 +12,7 @@
 #include "cinderx/Common/type.h"
 #include "cinderx/Jit/context.h"
 #include "cinderx/Jit/bytecode.h"
+#include "cinderx/Jit/jit_rt.h"
 #include "cinderx/Jit/hir/analysis.h"
 #include "cinderx/Jit/hir/clean_cfg.h"
 #include "cinderx/Jit/hir/copy_propagation.h"
@@ -23,6 +24,7 @@
 
 #include <fmt/ostream.h>
 
+#include <cstdlib>
 #include <cstring>
 
 namespace jit::hir {
@@ -34,6 +36,17 @@ bool useExactMethodCacheSplit() {
     const char* env = std::getenv("PYTHONJITEXACTMETHODCACHESPLIT");
     if (env == nullptr) {
       return 0;
+    }
+    return *env != '\0' && std::strcmp(env, "0") != 0;
+  }();
+  return enabled != 0;
+}
+
+bool sliceReverseFastPathEnabled() {
+  static int enabled = []() -> int {
+    const char* env = std::getenv("PYTHONJITENABLESLICEFASTPATH");
+    if (env == nullptr) {
+      return 1;
     }
     return *env != '\0' && std::strcmp(env, "0") != 0;
   }();
@@ -614,6 +627,65 @@ bool isLenDerivedInt(Register* reg) {
   }
 
   return false;
+}
+
+Register* stripTypeNarrowing(Register* reg) {
+  Register* cur = chaseAssignOperand(reg);
+  while (true) {
+    Instr* instr = cur->instr();
+    if (instr->IsGuardType() || instr->IsRefineType()) {
+      cur = chaseAssignOperand(instr->GetOperand(0));
+      continue;
+    }
+    return cur;
+  }
+}
+
+bool isNoneConst(Register* reg) {
+  Type ty = stripTypeNarrowing(reg)->type();
+  return ty <= TNoneType || (ty.hasObjectSpec() && ty.objectSpec() == Py_None);
+}
+
+bool isLongConstValue(Register* reg, int64_t value) {
+  auto boxed = getBoxedLongConst(stripTypeNarrowing(reg));
+  return boxed.has_value() && *boxed == value;
+}
+
+bool sameValueIgnoringNarrowing(Register* a, Register* b) {
+  return stripTypeNarrowing(a) == stripTypeNarrowing(b);
+}
+
+Register* matchLongAddOneFromBase(Register* reg, Register** base_out) {
+  Register* stop = stripTypeNarrowing(reg);
+  Register* lhs = nullptr;
+  Register* rhs = nullptr;
+
+  if (stop->instr()->IsLongBinaryOp()) {
+    auto* add = static_cast<const LongBinaryOp*>(stop->instr());
+    if (add->op() != BinaryOpKind::kAdd) {
+      return nullptr;
+    }
+    lhs = stripTypeNarrowing(add->left());
+    rhs = stripTypeNarrowing(add->right());
+  } else if (stop->instr()->IsBinaryOp()) {
+    auto* add = static_cast<const BinaryOp*>(stop->instr());
+    if (add->op() != BinaryOpKind::kAdd) {
+      return nullptr;
+    }
+    lhs = stripTypeNarrowing(add->left());
+    rhs = stripTypeNarrowing(add->right());
+  } else {
+    return nullptr;
+  }
+  if (isLongConstValue(lhs, 1)) {
+    *base_out = rhs;
+    return stop;
+  }
+  if (isLongConstValue(rhs, 1)) {
+    *base_out = lhs;
+    return stop;
+  }
+  return nullptr;
 }
 
 Register* unboxLenArithmeticInt(Register* reg) {
@@ -3363,6 +3435,49 @@ Register* simplifyStoreSubscr(Env& env, const StoreSubscr* instr) {
   Register* container = instr->GetOperand(0);
   Register* sub = instr->GetOperand(1);
   Register* value = instr->GetOperand(2);
+  Register* base_container = chaseAssignOperand(container);
+  Register* base_sub = chaseAssignOperand(sub);
+  Register* base_value = chaseAssignOperand(value);
+
+  // Recognize: list[:k+1] = list[k::-1]
+  //
+  // This is the hot flip shape in fannkuch. Lower to a dedicated runtime
+  // helper to avoid creating temporary slice objects on the common path.
+  if (sliceReverseFastPathEnabled() &&
+      base_sub->instr()->IsBuildSlice() && base_value->instr()->IsBinaryOp()) {
+    auto* lhs_slice = static_cast<const BuildSlice*>(base_sub->instr());
+    auto* rhs_subscr = static_cast<const BinaryOp*>(base_value->instr());
+    if (!(lhs_slice->NumOperands() == 2 &&
+          rhs_subscr->op() == BinaryOpKind::kSubscript &&
+          chaseAssignOperand(rhs_subscr->left()) == base_container &&
+          rhs_subscr->right()->instr()->IsBuildSlice())) {
+    } else {
+      auto* rhs_slice = static_cast<const BuildSlice*>(rhs_subscr->right()->instr());
+      if (rhs_slice->NumOperands() == 3 &&
+          isNoneConst(lhs_slice->start()) &&
+          isNoneConst(rhs_slice->stop()) &&
+          isLongConstValue(rhs_slice->step(), -1)) {
+        Register* rhs_start = rhs_slice->start();
+        Register* add_base = nullptr;
+        if (matchLongAddOneFromBase(lhs_slice->stop(), &add_base) != nullptr &&
+            sameValueIgnoringNarrowing(add_base, rhs_start)) {
+          Register* helper_list = container;
+          Register* helper_index = rhs_start;
+          auto output = env.func.env.AllocateRegister();
+          env.emitRawInstr<CallStatic>(
+              2,
+              output,
+              reinterpret_cast<void*>(JITRT_ListPrefixReverseAssign),
+              TCInt32,
+              helper_list,
+              helper_index);
+          env.emit<CheckNeg>(output, *instr->frameState());
+          env.optimized = true;
+          return nullptr;
+        }
+      }
+    }
+  }
 
   if (value->instr()->IsPrimitiveBox()) {
     auto* box = static_cast<const PrimitiveBox*>(value->instr());

--- a/cinderx/Jit/jit_rt.cpp
+++ b/cinderx/Jit/jit_rt.cpp
@@ -929,6 +929,93 @@ PyObject* JITRT_ListSlice(PyObject* list, PyObject* start, PyObject* stop) {
   return PyList_GetSlice(list, start_index, stop_index);
 }
 
+int JITRT_ListPrefixReverseAssign(PyObject* list, PyObject* index) {
+  if (!PyList_CheckExact(list) || !PyLong_CheckExact(index)) {
+    Ref<> minus_one = Ref<>::steal(PyLong_FromLong(-1));
+    if (minus_one == nullptr) {
+      return -1;
+    }
+    Ref<> one = Ref<>::steal(PyLong_FromLong(1));
+    if (one == nullptr) {
+      return -1;
+    }
+    Ref<> lhs_stop = Ref<>::steal(PyNumber_Add(index, one.get()));
+    if (lhs_stop == nullptr) {
+      return -1;
+    }
+    Ref<> rhs_slice =
+        Ref<>::steal(PySlice_New(index, Py_None, minus_one.get()));
+    if (rhs_slice == nullptr) {
+      return -1;
+    }
+    Ref<> lhs_slice = Ref<>::steal(PySlice_New(Py_None, lhs_stop.get(), Py_None));
+    if (lhs_slice == nullptr) {
+      return -1;
+    }
+    Ref<> rhs_value = Ref<>::steal(PyObject_GetItem(list, rhs_slice.get()));
+    if (rhs_value == nullptr) {
+      return -1;
+    }
+    return PyObject_SetItem(list, lhs_slice.get(), rhs_value.get());
+  }
+
+  Py_ssize_t idx = 0;
+  if (!_PyEval_SliceIndexNotNone(index, &idx)) {
+    return -1;
+  }
+
+  Py_ssize_t size = PyList_GET_SIZE(list);
+  if (size <= 1) {
+    return 0;
+  }
+
+  if (idx < 0) {
+    // Preserve full Python semantics for negative indices.
+    Ref<> minus_one = Ref<>::steal(PyLong_FromLong(-1));
+    if (minus_one == nullptr) {
+      return -1;
+    }
+    Ref<> one = Ref<>::steal(PyLong_FromLong(1));
+    if (one == nullptr) {
+      return -1;
+    }
+    Ref<> lhs_stop = Ref<>::steal(PyNumber_Add(index, one.get()));
+    if (lhs_stop == nullptr) {
+      return -1;
+    }
+    Ref<> rhs_slice =
+        Ref<>::steal(PySlice_New(index, Py_None, minus_one.get()));
+    if (rhs_slice == nullptr) {
+      return -1;
+    }
+    Ref<> lhs_slice = Ref<>::steal(PySlice_New(Py_None, lhs_stop.get(), Py_None));
+    if (lhs_slice == nullptr) {
+      return -1;
+    }
+    Ref<> rhs_value = Ref<>::steal(PyObject_GetItem(list, rhs_slice.get()));
+    if (rhs_value == nullptr) {
+      return -1;
+    }
+    return PyObject_SetItem(list, lhs_slice.get(), rhs_value.get());
+  }
+
+  if (idx >= size) {
+    idx = size - 1;
+  }
+
+  PyObject** items = reinterpret_cast<PyListObject*>(list)->ob_item;
+  Py_ssize_t lo = 0;
+  Py_ssize_t hi = idx;
+  while (lo < hi) {
+    PyObject* tmp = items[lo];
+    items[lo] = items[hi];
+    items[hi] = tmp;
+    ++lo;
+    --hi;
+  }
+  return 0;
+}
+
 #if PY_VERSION_HEX >= 0x030E0000 && PY_VERSION_HEX < 0x030F0000
 
 namespace {

--- a/cinderx/Jit/jit_rt.h
+++ b/cinderx/Jit/jit_rt.h
@@ -182,6 +182,14 @@ PyObject* JITRT_LoadGlobalsDict(PyThreadState* tstate);
  */
 PyObject* JITRT_ListSlice(PyObject* list, PyObject* start, PyObject* stop);
 
+/*
+ * Fast path for `list[:k+1] = list[k::-1]` on exact lists.
+ *
+ * Falls back to generic Python slicing semantics when operand types are not
+ * exact fast-path shapes. Returns 0 on success and -1 on error.
+ */
+int JITRT_ListPrefixReverseAssign(PyObject* list, PyObject* index);
+
 #if PY_VERSION_HEX >= 0x030E0000 && PY_VERSION_HEX < 0x030F0000
 /*
  * Exact-dict item lookup for try/except KeyError lowering.

--- a/cinderx/PythonLib/test_cinderx/test_arm_runtime.py
+++ b/cinderx/PythonLib/test_cinderx/test_arm_runtime.py
@@ -3494,6 +3494,101 @@ class ArmRuntimeTests(unittest.TestCase):
             self.assertEqual(int(lines[-2]), 0, proc.stdout)
             self.assertEqual(lines[-1], "([10, 20], 30, [40, 50])", proc.stdout)
 
+    def test_list_prefix_reverse_assign_lowers_to_runtime_fastpath(self) -> None:
+        code = textwrap.dedent(
+            """
+            import cinderx.jit as jit
+            import cinderjit
+
+            jit.enable()
+            jit.enable_specialized_opcodes()
+            jit.compile_after_n_calls(1000000)
+
+            def flip_prefix(perm, k):
+                perm[: k + 1] = perm[k::-1]
+                return perm
+
+            def flip_window(perm, k):
+                perm[1 : k + 1] = perm[k::-1]
+                return perm
+
+            def flip_stride(perm, k):
+                perm[: k + 1] = perm[k::2]
+                return perm
+
+            hot = [0, 1, 2, 3, 4]
+            for _ in range(200000):
+                flip_prefix(hot, 3)
+                flip_window(hot, 3)
+                flip_stride(hot, 3)
+
+            assert jit.force_compile(flip_prefix)
+            assert jit.force_compile(flip_window)
+            assert jit.force_compile(flip_stride)
+            counts = cinderjit.get_function_hir_opcode_counts(flip_prefix)
+            print(counts.get("CallStatic", 0))
+            print(counts.get("StoreSubscr", 0))
+
+            a = [0, 1, 2, 3, 4]
+            print(flip_prefix(a, 3))
+            b = [0, 1, 2, 3, 4]
+            print(flip_prefix(b, -1))
+            c = [0, 1, 2, 3, 4]
+            print(flip_window(c, 3))
+            d = [0, 1, 2, 3, 4]
+            print(flip_stride(d, 3))
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            script = f"{tmp}/list_prefix_reverse_assign_fastpath.py"
+            with open(script, "w", encoding="utf-8") as fp:
+                fp.write(code)
+
+            proc = subprocess.run(
+                [sys.executable, script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "PYTHONJITENABLESLICEFASTPATH": "0"},
+            )
+            self.assertEqual(
+                proc.returncode,
+                0,
+                f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+            )
+            lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+            self.assertGreaterEqual(len(lines), 6, proc.stdout)
+            off_callstatic = int(lines[-6])
+            off_storesubscr = int(lines[-5])
+            self.assertEqual(lines[-4], "[3, 2, 1, 0, 4]", proc.stdout)
+            self.assertEqual(lines[-3], "[4, 3, 2, 1, 0, 0, 1, 2, 3, 4]", proc.stdout)
+            self.assertEqual(lines[-2], "[0, 3, 2, 1, 0, 4]", proc.stdout)
+            self.assertEqual(lines[-1], "[3, 4]", proc.stdout)
+
+            proc = subprocess.run(
+                [sys.executable, script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "PYTHONJITENABLESLICEFASTPATH": "1"},
+            )
+            self.assertEqual(
+                proc.returncode,
+                0,
+                f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+            )
+            lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+            self.assertGreaterEqual(len(lines), 6, proc.stdout)
+            on_callstatic = int(lines[-6])
+            on_storesubscr = int(lines[-5])
+            self.assertGreaterEqual(on_callstatic, off_callstatic + 1, proc.stdout)
+            self.assertLess(on_storesubscr, off_storesubscr, proc.stdout)
+            self.assertEqual(lines[-4], "[3, 2, 1, 0, 4]", proc.stdout)
+            self.assertEqual(lines[-3], "[4, 3, 2, 1, 0, 0, 1, 2, 3, 4]", proc.stdout)
+            self.assertEqual(lines[-2], "[0, 3, 2, 1, 0, 4]", proc.stdout)
+            self.assertEqual(lines[-1], "[3, 4]", proc.stdout)
+
     def test_istruthy_bool_uses_pointer_compare_fast_path(self) -> None:
         # Regression guard:
         # bool-heavy truthiness checks should not rely solely on


### PR DESCRIPTION
**概述**  
本 PR 为以下精确形态增加了专用优化：

`lst[:k+1] = lst[k::-1]`

当 HIR 识别到该形态时，会把 `StoreSubscr` 降级为运行时 helper 调用，绕开通用切片/下标赋值路径，降低热点重排场景中的开销。

**主要内容**  
- 在 HIR 中新增精确形态匹配并做 lowering，约束包括：
  - `lhs.start is None`
  - `lhs.stop == rhs.start + 1`
  - `rhs.stop is None`
  - `rhs.step == -1`
  - 左右两侧容器一致
- 新增运行时 helper：
  - `JITRT_ListPrefixReverseAssign(PyObject* list, PyObject* index)`
  - 对 `exact list + exact int` 走原地快路径
  - 非精确场景回退通用 Python 语义，保证正确性
- 开关：
  - `PYTHONJITENABLESLICEFASTPATH`
  - 默认开启，设为 `0` 可关闭
- 回归测试：
  - 覆盖开关 OFF/ON 的 lowering 行为
  - 覆盖目标形态与非目标形态的语义一致性

**正确性说明**  
- fastpath 只对精确 `[:k+1] = [k::-1]` 生效。  
- 其他切片形态不误匹配，继续走通用语义。  
- 匹配逻辑对 HIR 的 type narrowing 形态有鲁棒性，避免命中率回退。

**性能结果**  
```
+-------------------------+------------------------------+------------------------------+
| Benchmark               | cinderx-b283d601-0327-213312 | cinderx-a9e8db8f-0327-223255 |
+=========================+==============================+==============================+
| fannkuch                | 253 ms                       | 224 ms: 1.13x faster         |
+-------------------------+------------------------------+------------------------------+
| richards_super          | 44.7 ms                      | 40.6 ms: 1.10x faster        |
+-------------------------+------------------------------+------------------------------+
| nqueens                 | 58.3 ms                      | 57.2 ms: 1.02x faster        |
+-------------------------+------------------------------+------------------------------+
| richards                | 36.3 ms                      | 35.8 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| deepcopy_reduce         | 2.16 us                      | 2.14 us: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| chaos                   | 42.1 ms                      | 41.8 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_sparse_mat_mult | 2.87 ms                      | 2.85 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_fft             | 122 ms                       | 121 ms: 1.01x faster         |
+-------------------------+------------------------------+------------------------------+
| deepcopy_memo           | 24.3 us                      | 24.2 us: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| deltablue               | 3.76 ms                      | 3.74 ms: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| comprehensions          | 12.2 us                      | 12.2 us: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| hexiom                  | 4.74 ms                      | 4.73 ms: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_monte_carlo     | 51.2 ms                      | 51.3 ms: 1.00x slower        |
+-------------------------+------------------------------+------------------------------+
| deepcopy                | 210 us                       | 211 us: 1.00x slower         |
+-------------------------+------------------------------+------------------------------+
| go                      | 57.0 ms                      | 57.3 ms: 1.01x slower        |
+-------------------------+------------------------------+------------------------------+
| spectral_norm           | 65.9 ms                      | 66.4 ms: 1.01x slower        |
+-------------------------+------------------------------+------------------------------+
| scimark_sor             | 96.9 ms                      | 97.5 ms: 1.01x slower        |
+-------------------------+------------------------------+------------------------------+
| unpack_sequence         | 3.71 ns                      | 3.77 ns: 1.02x slower        |
+-------------------------+------------------------------+------------------------------+
| tomli_loads             | 1.95 sec                     | 1.98 sec: 1.02x slower       |
+-------------------------+------------------------------+------------------------------+
| Geometric mean          | (ref)                        | 1.01x faster                 |
+-------------------------+------------------------------+------------------------------+
```

**改动文件**  
- `cinderx/Jit/hir/simplify.cpp`  
- `cinderx/Jit/jit_rt.h`  
- `cinderx/Jit/jit_rt.cpp`  
- `cinderx/PythonLib/test_cinderx/test_arm_runtime.py`