### PR TITLE
Fix the deopt issue in the unpickle_pure_python case.

### DIFF
--- a/cinderx/Jit/hir/builder.cpp
+++ b/cinderx/Jit/hir/builder.cpp
@@ -4424,13 +4424,10 @@ void HIRBuilder::emitToBool(
   if (bc_instr != nullptr && getConfig().specialized_opcodes) {
     switch (bc_instr->specializedOpcode()) {
 #if PY_VERSION_HEX >= 0x030E0000
-      case TO_BOOL_NONE: {
-        tc.emit<GuardType>(operand, TNoneType, operand, tc.frame);
-        Register* false_obj = temps_.AllocateStack();
-        tc.emit<LoadConst>(false_obj, Type::fromObject(Py_False));
-        tc.frame.stack.push(false_obj);
-        return;
-      }
+      // CPython's adaptive TO_BOOL_NONE is only a quickening hint: non-None
+      // values fall back to generic TO_BOOL in the interpreter. Lowering it to
+      // a permanent None guard in JIT code turns shape changes into repeated
+      // deopts, so we intentionally leave it on the generic path here.
       case TO_BOOL_BOOL:
         tc.emit<GuardType>(operand, TBool, operand, tc.frame);
         tc.frame.stack.push(operand);

--- a/cinderx/PythonLib/test_cinderx/test_arm_runtime.py
+++ b/cinderx/PythonLib/test_cinderx/test_arm_runtime.py
@@ -245,6 +245,75 @@ class ArmRuntimeTests(unittest.TestCase):
             self.assertEqual(int(lines[-2]), 0, proc.stdout)
             self.assertEqual(int(lines[-1]), 800, proc.stdout)
 
+    def test_to_bool_none_specialization_avoids_repeated_non_none_deopts(self) -> None:
+        # Regression guard:
+        # adaptive TO_BOOL_NONE in the interpreter is only a quickening hint.
+        # The JIT must not compile it into a permanent "value is None" guard,
+        # otherwise later non-None falsey values deopt on every execution.
+        code = textwrap.dedent(
+            """
+            import dis
+            import cinderx.jit as jit
+
+            jit.enable()
+            jit.enable_specialized_opcodes()
+            jit.compile_after_n_calls(1000000)
+
+            class Falsey:
+                def __bool__(self):
+                    return False
+
+            def f(x):
+                if x:
+                    return 1
+                return 0
+
+            for _ in range(200000):
+                f(None)
+
+            opnames = [instr.opname for instr in dis.get_instructions(f, adaptive=True)]
+            assert "TO_BOOL_NONE" in opnames, opnames
+            assert jit.force_compile(f)
+            assert jit.is_jit_compiled(f)
+
+            jit.get_and_clear_runtime_stats()
+            total = 0
+            for _ in range(200):
+                total += f(Falsey())
+
+            stats = jit.get_and_clear_runtime_stats()
+            deopt_count = sum(
+                entry["int"]["count"]
+                for entry in stats.get("deopt", [])
+                if entry["normal"]["func_qualname"] == "f"
+            )
+            print(deopt_count)
+            print(total)
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            script = f"{tmp}/to_bool_none_no_repeated_deopt.py"
+            with open(script, "w", encoding="utf-8") as fp:
+                fp.write(code)
+
+            proc = subprocess.run(
+                [sys.executable, script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=dict(os.environ),
+            )
+            self.assertEqual(
+                proc.returncode,
+                0,
+                f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+            )
+            lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+            self.assertGreaterEqual(len(lines), 2, proc.stdout)
+            self.assertEqual(int(lines[-2]), 0, proc.stdout)
+            self.assertEqual(int(lines[-1]), 0, proc.stdout)
+
     def test_specialized_numeric_leaf_mixed_types_avoid_deopts(self) -> None:
         # Regression guard:
         # specialized numeric opcodes should not pin no-backedge leaf helpers

--- a/docs/plans/2026-03-29-issue4-unpickle-tobool-none-analysis.md
+++ b/docs/plans/2026-03-29-issue4-unpickle-tobool-none-analysis.md
@@ -1,0 +1,60 @@
+# Issue #4: `TO_BOOL_NONE` 通用修复*
+## 问题定义
+
+`pickle._Unframer.read` 的 `if self.current_frame:` 在 Python 3.14 下会被 quicken 成 `TO_BOOL_NONE`。
+
+之前 JIT 对 `TO_BOOL_NONE` 的 lowering 是：
+
+- `GuardType(TNoneType)`
+- `LoadConst(Py_False)`
+
+这会把解释器里的“自适应专门化命中形状”编译成“JIT 中必须永远是 `None`”的稳定承诺。
+
+结果是：
+
+- 热起来时如果该站点先看到 `None`，就会编译出 `GuardType(TNoneType)`。
+- 之后一旦站点合法地看到非 `None` 值，就会在 JIT 中持续 deopt。
+
+`unpickle_pure_python` 暴露了这个问题，但它不是 `_Unframer` 的私有问题，而是 `TO_BOOL_NONE` lowering 的通用问题。
+
+## 根因
+
+CPython 3.14 对 `TO_BOOL_NONE` 的解释器语义并不是“该值必须始终是 `None`”，而是：
+
+- 若值仍然是 `None`，走快速路径并返回 `False`
+- 若值不是 `None`，则 miss 回退到通用 `TO_BOOL`
+
+也就是说，`TO_BOOL_NONE` 在解释器里只是一个 quickening hint，而不是稳定类型承诺。
+
+本地仓库里的 3.14 生成解释器代码已经能直接看到这一点：
+
+- `cinderx/Interpreter/3.14/Includes/generated_cases.c.h`
+
+其中 `TO_BOOL_NONE` 的关键逻辑是：
+
+- `if (!PyStackRef_IsNone(value)) { ... JUMP_TO_PREDICTED(TO_BOOL); }`
+
+因此，JIT 之前把它翻译成 `GuardType(TNoneType)` 是过度特化。
+
+## 设计目标
+
+1. 从根上修复 `TO_BOOL_NONE` 的 JIT 语义。
+2. 不再依赖 `_Unframer` 这样的 workload 特判。
+3. 保住 `go` 的最佳性能附近。
+4. 让 `unpickle_pure_python` 去掉 deopt 后不要出现严重劣化。
+
+## 最终方案
+
+JIT 不再对 `TO_BOOL_NONE` 做专门 lowering。
+
+具体做法：
+
+- 保留 `TO_BOOL_BOOL / INT / LIST / STR` 的专门 lowering。
+- 删除 `TO_BOOL_NONE -> GuardType(TNoneType) + False` 这一分支。
+- 让 `TO_BOOL_NONE` 自然落回通用 `TO_BOOL` 路径，也就是：
+  - `IsTruthy`
+  - `PrimitiveBoxBool`
+
+对应代码位置：
+
+- `cinderx/Jit/hir/builder.cpp`


### PR DESCRIPTION
## 修复说明
- 用例go的优化(https://github.com/113xiaoji/cinderx/pull/72) 对unpickle_pure_python 用例引起了deopt 
`pickle._Unframer.read` 的 `if self.current_frame:` 在 Python 3.14 下会被 quicken 成 `TO_BOOL_NONE`。

之前 JIT 对 `TO_BOOL_NONE` 的 lowering 是：

- `GuardType(TNoneType)`
- `LoadConst(Py_False)`

这会把解释器里的“自适应专门化命中形状”编译成“JIT 中必须永远是 `None`”的稳定承诺。

结果是：

- 热起来时如果该站点先看到 `None`，就会编译出 `GuardType(TNoneType)`。
- 之后一旦站点合法地看到非 `None` 值，就会在 JIT 中持续 deopt。

`unpickle_pure_python` 暴露了这个问题，但它不是 `_Unframer` 的私有问题，而是 `TO_BOOL_NONE` lowering 的通用问题。
## 最终方案

JIT 不再对 `TO_BOOL_NONE` 做专门 lowering。

## 测试结果

<img width="515" height="545" alt="image" src="https://github.com/user-attachments/assets/b2f304be-4c42-4f17-bf7a-d64986d27c53" />
