### PR TITLE
Fix asyncio_tcp issue#77

### DIFF
--- a/cinderx/Jit/hir/long_loop_unboxing.cpp
+++ b/cinderx/Jit/hir/long_loop_unboxing.cpp
@@ -341,6 +341,13 @@ Register* materializeInvariantRawLong(
     return it->second;
   }
 
+  if (!(reg->type() <= TCInt64) && !getBoxedLongConst(reg).has_value()) {
+    Instr* def_instr = reg->instr();
+    if (def_instr == nullptr || def_instr->block() != candidate.preheader) {
+      return nullptr;
+    }
+  }
+
   const FrameState* frame =
       candidate.preheader->GetTerminator()->getDominatingFrameState();
   if (frame == nullptr) {


### PR DESCRIPTION
## 修改说明
最终保留的修复逻辑：
- `materializeInvariantRawLong(...)` 想在 loop preheader 中 materialize 一个non-constant boxed long 对应的 raw long 时，先要求这个 boxed value 本身已经在 preheader 中定义完成，如果 boxed value 实际上是在 loop body 里才定义出来，就直接放弃这次materialize

这样做的目的：
- 防止 `LongLoopUnboxing` 把“循环体里未来才会出现的 boxed long”错误地当成loop-invariant
- 防止在 HIR 中制造 use-before-def
## 测试结果
- 用例执行成功截图
<img width="1344" height="149" alt="image" src="https://github.com/user-attachments/assets/d7ad8034-32ed-4d0c-991b-6feb4b295538" />
- 全量测试结果，未引入劣化
<img width="1126" height="103" alt="image" src="https://github.com/user-attachments/assets/452f947b-f6c0-4448-8c94-a55d5a64e359" />

<img width="740" height="587" alt="image" src="https://github.com/user-attachments/assets/124165aa-6dae-4186-8a06-0705d35186d7" />

