### PR TITLE
JIT：恢复 self-only float 方法的 fastpath，修复 float 回退

### DIFF
--- a/cinderx/Jit/hir/builder.cpp
+++ b/cinderx/Jit/hir/builder.cpp
@@ -372,6 +372,17 @@ bool hasInferredNonSelfArgType(const Preloader& preloader) {
   return false;
 }
 
+bool hasStableSelfOnlyMethodType(const Preloader& preloader) {
+  return preloader.numArgs() == 1 && preloader.inferredSelfType().has_value();
+}
+
+bool shouldSpecializeFloatGuards(
+    BorrowedRef<PyCodeObject> code,
+    const Preloader& preloader) {
+  return codeHasBackedge(code) || hasStableSelfOnlyMethodType(preloader) ||
+      hasInferredNonSelfArgType(preloader);
+}
+
 Register* chaseAssign(Register* reg) {
   while (reg != nullptr && reg->instr()->IsAssign()) {
     reg = reg->instr()->GetOperand(0);
@@ -3755,13 +3766,14 @@ void HIRBuilder::emitBinaryOp(
   // functions, but can be actively harmful for tiny mixed-numeric leaf helpers
   // like raytrace's Vector.dot(). Keep the int guards only for code objects
   // that actually contain a backedge. Keep float exact guards for either
-  // loop-hot code or the narrow issue31-style leaf methods where we inferred
-  // a stable exact non-self argument type. Self-only helpers like
-  // Vector.scale() and generic helpers like addColours() should not keep the
-  // no-backedge float exact guards.
+  // loop-hot code, stable self-only leaf methods like bm_float's
+  // Point.normalize(), or the narrow issue31-style leaf methods where we
+  // inferred a stable exact non-self argument type. Self+factor helpers like
+  // Vector.scale() and generic helpers like addColours() should still stay on
+  // the no-guard generic path.
   bool specialize_int_guards = codeHasBackedge(code_);
   bool specialize_float_guards =
-      codeHasBackedge(code_) || hasInferredNonSelfArgType(preloader_);
+      shouldSpecializeFloatGuards(code_, preloader_);
   if (getConfig().specialized_opcodes) {
     switch (bc_instr.specializedOpcode()) {
       case BINARY_OP_ADD_INT:
@@ -4385,7 +4397,7 @@ void HIRBuilder::emitCompareOp(
   CompareOp op = static_cast<CompareOp>(compare_op);
   bool specialize_int_guards = codeHasBackedge(code_);
   bool specialize_float_guards =
-      codeHasBackedge(code_) || hasInferredNonSelfArgType(preloader_);
+      shouldSpecializeFloatGuards(code_, preloader_);
   if (getConfig().specialized_opcodes) {
     switch (bc_instr.specializedOpcode()) {
       case COMPARE_OP_FLOAT:

--- a/cinderx/PythonLib/test_cinderx/test_arm_runtime.py
+++ b/cinderx/PythonLib/test_cinderx/test_arm_runtime.py
@@ -2246,6 +2246,78 @@ class ArmRuntimeTests(unittest.TestCase):
             self.assertIn("DoubleBinaryOp<Subtract>", dump)
             self.assertIn("DoubleBinaryOp<Multiply>", dump)
 
+    def test_self_only_float_leaf_method_keeps_double_fastpath(self) -> None:
+        # Regression guard:
+        # self-only float helpers like bm_float's Point.normalize() should keep
+        # the unboxed float fast path even without a backedge or non-self args.
+        code = textwrap.dedent(
+            """
+            from math import cos, sin, sqrt
+
+            import cinderx.jit as jit
+            import cinderjit
+
+            jit.enable()
+            jit.enable_specialized_opcodes()
+            jit.compile_after_n_calls(1000000)
+
+            class Point:
+                __slots__ = ("x", "y", "z")
+
+                def __init__(self, i):
+                    self.x = x = sin(i)
+                    self.y = cos(i) * 3.0
+                    self.z = (x * x) / 2.0
+
+                def normalize(self):
+                    x = self.x
+                    y = self.y
+                    z = self.z
+                    norm = sqrt(x * x + y * y + z * z)
+                    self.x /= norm
+                    self.y /= norm
+                    self.z /= norm
+
+            p = Point(1.25)
+            for _ in range(10000):
+                p.normalize()
+
+            assert jit.force_compile(Point.normalize)
+            counts = cinderjit.get_function_hir_opcode_counts(Point.normalize)
+            print(counts.get("DoubleBinaryOp", 0))
+            print(counts.get("DoubleSqrt", 0))
+            print(counts.get("VectorCall", 0))
+            print(counts.get("BinaryOp", 0))
+            print(p.normalize())
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            script = f"{tmp}/float_self_only_normalize.py"
+            with open(script, "w", encoding="utf-8") as fp:
+                fp.write(code)
+
+            proc = subprocess.run(
+                [sys.executable, script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=dict(os.environ),
+            )
+            self.assertEqual(
+                proc.returncode,
+                0,
+                f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+            )
+
+            lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+            self.assertGreaterEqual(len(lines), 5, proc.stdout)
+            self.assertGreaterEqual(int(lines[-5]), 5, proc.stdout)
+            self.assertGreaterEqual(int(lines[-4]), 1, proc.stdout)
+            self.assertEqual(int(lines[-3]), 0, proc.stdout)
+            self.assertEqual(int(lines[-2]), 0, proc.stdout)
+            self.assertEqual(lines[-1], "None", proc.stdout)
+
     def test_float_pow_two_lowers_to_double_multiply(self) -> None:
         # Regression guard:
         # exact-float `x ** 2` should strength-reduce to the same unboxed


### PR DESCRIPTION
**概述**  
本 PR 收窄了 no-backedge 场景下 float exact guard 的保留条件，修复了 `bm_float` 中 self-only float leaf method 的性能回退，同时保留此前为避免 `raytrace` 回退而引入的收益。

问题背景是：此前为了避免 `raytrace` 这类 mixed-numeric leaf helper 上的回退，no-backedge 场景下的 float exact guard 被整体放宽；但这也让 `bm_float` 里的 `Point.normalize()` 这类 self-only 方法失去了 unboxed double fastpath，导致性能回退。

本 PR 不回退之前的整体方向，而是把 float guard 的保留策略改成更精确的条件判断。

**主要内容**  
- 在 HIR builder 中新增 `shouldSpecializeFloatGuards()`，统一 float exact guard 的判定逻辑
- 在以下场景保留 float exact guard：
  - code object 自身有 backedge
  - 推断出稳定的 non-self 参数精确类型
  - self-only method，且能推断出稳定的 `self` 类型
- 继续让以下场景走 no-guard 的通用路径：
  - `raytrace` 里这类 `self + factor` 的 mixed-numeric helper
  - 泛型 helper，例如 `addColours()`
- 回归测试：
  - 新增 self-only float leaf method 的回归测试
  - 验证 `Point.normalize()` 仍然走 unboxed double lowering，而不是退回 generic `BinaryOp`

**正确性说明**  
- 这次修改不是重新放开所有 no-backedge float exact guard，而是只恢复对“稳定 self-only method”的专用 fastpath。
- `bm_float` 里的 `Point.normalize()` 能重新命中 double fastpath。
- `raytrace` 中容易出现 mixed `int/float` 的 helper 仍然保持通用路径，避免重新引入此前的性能回退。
- 新增测试会检查编译后的 HIR opcode 计数，确保：
  - 存在 `DoubleBinaryOp`
  - 存在 `DoubleSqrt`
  - 不退化为 generic `BinaryOp`
  - 不依赖 `VectorCall`

** 性能结果 **
```
All benchmarks:
===============

+-------------------------+------------------------------+------------------------------+
| Benchmark               | cinderx-0e33e45b-0330-194014 | cinderx-f8d11be3-0330-192832 |
+=========================+==============================+==============================+
| float                   | 48.5 ms                      | 43.1 ms: 1.13x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_monte_carlo     | 51.2 ms                      | 49.4 ms: 1.04x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_fft             | 122 ms                       | 120 ms: 1.01x faster         |
+-------------------------+------------------------------+------------------------------+
| deepcopy                | 210 us                       | 208 us: 1.01x faster         |
+-------------------------+------------------------------+------------------------------+
| go                      | 56.5 ms                      | 56.2 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_sor             | 97.7 ms                      | 97.2 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| comprehensions          | 12.2 us                      | 12.1 us: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| hexiom                  | 4.74 ms                      | 4.72 ms: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| coroutines              | 31.7 ms                      | 31.8 ms: 1.00x slower        |
+-------------------------+------------------------------+------------------------------+
| coverage                | 5.50 ms                      | 5.51 ms: 1.00x slower        |
+-------------------------+------------------------------+------------------------------+
| scimark_sparse_mat_mult | 2.85 ms                      | 2.87 ms: 1.00x slower        |
+-------------------------+------------------------------+------------------------------+
| richards                | 35.6 ms                      | 36.1 ms: 1.01x slower        |
+-------------------------+------------------------------+------------------------------+
| nqueens                 | 57.2 ms                      | 58.4 ms: 1.02x slower        |
+-------------------------+------------------------------+------------------------------+
| Geometric mean          | (ref)                        | 1.01x faster                 |
+-------------------------+------------------------------+------------------------------+

Benchmark hidden because not significant (13): tomli_loads, nbody, chaos, richards_super, deepcopy_memo, scimark_lu, fannkuch, spectral_norm, raytrace, unpack_sequence, deltablue, generators, deepcopy_reduce
```
