### PR TITLE
perf: only count calls for JIT-pending functions

### DIFF
--- a/cinderx/Interpreter/3.12/interpreter.c
+++ b/cinderx/Interpreter/3.12/interpreter.c
@@ -506,15 +506,24 @@ Ci_EvalFrame(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
     stack_pointer = _PyFrame_GetStackPointer(frame);
 
 start_frame:
-    // Update call count.
+    // Update call count. Only count calls for functions pending JIT compilation
+    // (vectorcall == Ci_jit_vectorcall). All other functions (stdlib, already
+    // compiled, non-JIT) skip this entirely to avoid unnecessary overhead.
     {
-        PyCodeObject* code = frame->f_code;
-        CodeExtra *extra = codeExtra(code);
-        if (extra != NULL) {
-            extra->calls += 1;
-            adaptive_enabled = is_adaptive_enabled(extra);
+        PyObject *fobj = frame->f_funcobj;
+        if (Ci_jit_vectorcall != NULL &&
+                PyFunction_Check(fobj) &&
+                ((PyFunctionObject*)fobj)->vectorcall == Ci_jit_vectorcall) {
+            PyCodeObject* code = frame->f_code;
+            CodeExtra *extra = codeExtra(code);
+            if (extra != NULL) {
+                extra->calls += 1;
+                adaptive_enabled = is_adaptive_enabled(extra);
+            } else {
+                adaptive_enabled = false;
+            }
         } else {
-            adaptive_enabled = false;
+            adaptive_enabled = !Ci_DelayAdaptiveCode;
         }
     }
 

--- a/cinderx/Interpreter/3.14/Includes/ceval_macros.h
+++ b/cinderx/Interpreter/3.14/Includes/ceval_macros.h
@@ -474,13 +474,17 @@ do { \
 #define CI_SET_ADAPTIVE_INTERPRETER_ENABLED_STATE ((void)0);
 #define CI_UPDATE_CALL_COUNT \
     do { \
-        PyObject *executable = PyStackRef_AsPyObjectBorrow(frame->f_executable); \
-        if (PyCode_Check(executable)) { \
-            PyCodeObject* code = (PyCodeObject*)executable; \
-            if (!(code->co_flags & CO_NO_MONITORING_EVENTS)) { \
-                CodeExtra *extra = codeExtra(code); \
-                if (extra != NULL) { \
-                    Ci_code_extra_incr_calls(extra); \
+        if (Ci_jit_vectorcall != NULL) { \
+            PyObject *fobj = PyStackRef_AsPyObjectBorrow(frame->f_funcobj); \
+            if (PyFunction_Check(fobj) && \
+                ((PyFunctionObject*)fobj)->vectorcall == Ci_jit_vectorcall) { \
+                PyObject *executable = PyStackRef_AsPyObjectBorrow(frame->f_executable); \
+                if (PyCode_Check(executable)) { \
+                    PyCodeObject* code = (PyCodeObject*)executable; \
+                    CodeExtra *extra = codeExtra(code); \
+                    if (extra != NULL) { \
+                        Ci_code_extra_incr_calls(extra); \
+                    } \
                 } \
             } \
         } \

--- a/cinderx/Interpreter/3.14/interpreter.c
+++ b/cinderx/Interpreter/3.14/interpreter.c
@@ -6,6 +6,7 @@
 
 #include "cinderx/UpstreamBorrow/borrowed.h"
 #include "cinderx/Interpreter/cinder_opcode.h"
+#include "cinderx/Interpreter/interpreter.h"
 
 #include "cinderx/module_c_state.h"
 

--- a/cinderx/Interpreter/3.15/interpreter.c
+++ b/cinderx/Interpreter/3.15/interpreter.c
@@ -6,6 +6,7 @@
 
 #include "cinderx/UpstreamBorrow/borrowed.h"
 #include "cinderx/Interpreter/cinder_opcode.h"
+#include "cinderx/Interpreter/interpreter.h"
 
 #include "cinderx/module_c_state.h"
 
@@ -446,16 +447,23 @@ Py_ssize_t load_method_static_cached_oparg_slot(int oparg) {
 
 #define CI_UPDATE_CALL_COUNT                                                 \
   do {                                                                       \
-    PyObject* executable = PyStackRef_AsPyObjectBorrow(frame->f_executable); \
-    if (PyCode_Check(executable)) {                                          \
-      PyCodeObject* code = (PyCodeObject*)executable;                        \
-      if (!(code->co_flags & CO_NO_MONITORING_EVENTS)) {                     \
-        CodeExtra* extra = codeExtra(code);                                  \
-        if (extra == NULL) {                                                 \
-          adaptive_enabled = false;                                          \
-        } else {                                                             \
-          Ci_code_extra_incr_calls(extra);                                   \
-          adaptive_enabled = is_adaptive_enabled(extra);                     \
+    if (Ci_jit_vectorcall != NULL) {                                         \
+      PyObject* fobj = PyStackRef_AsPyObjectBorrow(frame->f_funcobj);        \
+      if (PyFunction_Check(fobj) &&                                          \
+          ((PyFunctionObject*)fobj)->vectorcall == Ci_jit_vectorcall) {      \
+        PyObject* executable =                                               \
+            PyStackRef_AsPyObjectBorrow(frame->f_executable);                \
+        if (PyCode_Check(executable)) {                                      \
+          PyCodeObject* code = (PyCodeObject*)executable;                    \
+          if (!(code->co_flags & CO_NO_MONITORING_EVENTS)) {                 \
+            CodeExtra* extra = codeExtra(code);                              \
+            if (extra == NULL) {                                             \
+              adaptive_enabled = false;                                      \
+            } else {                                                         \
+              Ci_code_extra_incr_calls(extra);                               \
+              adaptive_enabled = is_adaptive_enabled(extra);                 \
+            }                                                                \
+          }                                                                  \
         }                                                                    \
       }                                                                      \
     }                                                                        \

--- a/cinderx/Interpreter/interpreter.h
+++ b/cinderx/Interpreter/interpreter.h
@@ -71,6 +71,10 @@ void Ci_InitOpcodes();
 extern bool Ci_DelayAdaptiveCode;
 extern uint64_t Ci_AdaptiveThreshold;
 
+// The JIT vectorcall entry point, or NULL if the JIT is not active.
+// Used by the interpreter loop to skip call counting for non-JIT functions.
+extern vectorcallfunc Ci_jit_vectorcall;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cinderx/Jit/pyjit.cpp
+++ b/cinderx/Jit/pyjit.cpp
@@ -189,6 +189,10 @@ PyObject* forcedJitVectorcall(
   return interp_entry(func_obj, stack, nargsf, kwnames);
 }
 
+// Exposed to the interpreter loop (C code) so it can check whether a function
+// is pending JIT compilation without pulling in C++ headers.
+extern "C" vectorcallfunc Ci_jit_vectorcall = nullptr;
+
 // Python function entry point when the JIT is enabled.
 PyObject* jitVectorcall(
     PyObject* func_obj,
@@ -3597,6 +3601,7 @@ int initialize() {
   }
 
   getMutableConfig().state = State::kRunning;
+  ::Ci_jit_vectorcall = reinterpret_cast<vectorcallfunc>(jitVectorcall);
 
   mod_state->jit_list = std::move(jit_list);
 
@@ -3624,6 +3629,7 @@ void finalize() {
   // Disable the JIT first so nothing we do in here ends up attempting to
   // invoke the JIT while we're finalizing our data structures.
   getMutableConfig().state = State::kFinalizing;
+  ::Ci_jit_vectorcall = nullptr;
 
   // Deopt all JIT generators, since JIT generators reference code and other
   // metadata that we will be freeing later in this function.


### PR DESCRIPTION
## 背景

当前解释器循环会为大量并不需要依赖调用计数触发 JIT 的函数更新 call count，包括 stdlib、helper 函数以及未进入 JIT pending 状态的普通 Python 函数。这部分开销在 `jitlist` 或“热点较少、库调用较多”的 `autojit` 场景里比较明显。

这组改动把调用计数收敛到真正需要它的函数上：只有已经挂到 JIT pending 路径上的函数才继续累计 call count，其余函数跳过这一步。

## 改动

- 在解释器循环中，仅对 `vectorcall == Ci_jit_vectorcall` 的函数更新 call count
- 暴露 `Ci_jit_vectorcall` 给解释器侧使用，避免引入 C++ 头依赖
- 在 3.12、3.14、3.15 路径上统一 pending 函数识别逻辑

## 效果

在 ARM 上重新验证后：

- `deepcopy`、`django_template` 这类“少量 JIT 热点 + 大量库调用”的 workload 有稳定正收益
- `nbody` 这类热点本身就是 JIT 目标的用例，性能基本中性

## 验证
```
All benchmarks:
===============

+-------------------------+------------------------------+------------------------------+
| Benchmark               | cinderx-46297bb6-0408-162203 | cinderx-70959422-0408-160023 |
+=========================+==============================+==============================+
| django_template         | 35.7 ms                      | 34.9 ms: 1.03x faster        |
+-------------------------+------------------------------+------------------------------+
| sympy_sum               | 124 ms                       | 121 ms: 1.03x faster         |
+-------------------------+------------------------------+------------------------------+
| sympy_expand            | 365 ms                       | 356 ms: 1.03x faster         |
+-------------------------+------------------------------+------------------------------+
| nqueens                 | 58.8 ms                      | 57.5 ms: 1.02x faster        |
+-------------------------+------------------------------+------------------------------+
| sympy_str               | 224 ms                       | 219 ms: 1.02x faster         |
+-------------------------+------------------------------+------------------------------+
| sympy_integrate         | 17.1 ms                      | 16.8 ms: 1.02x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_sparse_mat_mult | 2.88 ms                      | 2.83 ms: 1.02x faster        |
+-------------------------+------------------------------+------------------------------+
| 2to3                    | 301 ms                       | 296 ms: 1.02x faster         |
+-------------------------+------------------------------+------------------------------+
| logging_format          | 6.53 us                      | 6.43 us: 1.02x faster        |
+-------------------------+------------------------------+------------------------------+
| logging_simple          | 6.15 us                      | 6.07 us: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| tomli_loads             | 1.95 sec                     | 1.93 sec: 1.01x faster       |
+-------------------------+------------------------------+------------------------------+
| fannkuch                | 225 ms                       | 223 ms: 1.01x faster         |
+-------------------------+------------------------------+------------------------------+
| chaos                   | 42.0 ms                      | 41.6 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| go                      | 55.8 ms                      | 55.4 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| scimark_monte_carlo     | 49.8 ms                      | 49.6 ms: 1.01x faster        |
+-------------------------+------------------------------+------------------------------+
| spectral_norm           | 65.6 ms                      | 65.3 ms: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| generators              | 56.4 ms                      | 56.2 ms: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| deepcopy                | 212 us                       | 211 us: 1.00x faster         |
+-------------------------+------------------------------+------------------------------+
| coroutines              | 32.9 ms                      | 32.8 ms: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| richards_super          | 40.7 ms                      | 40.6 ms: 1.00x faster        |
+-------------------------+------------------------------+------------------------------+
| coverage                | 6.55 ms                      | 6.57 ms: 1.00x slower        |
+-------------------------+------------------------------+------------------------------+
| hexiom                  | 4.75 ms                      | 4.77 ms: 1.00x slower        |
+-------------------------+------------------------------+------------------------------+
| scimark_sor             | 97.0 ms                      | 97.4 ms: 1.00x slower        |
+-------------------------+------------------------------+------------------------------+
| deepcopy_memo           | 24.1 us                      | 24.2 us: 1.01x slower        |
+-------------------------+------------------------------+------------------------------+
| logging_silent          | 119 ns                       | 120 ns: 1.01x slower         |
+-------------------------+------------------------------+------------------------------+
| scimark_lu              | 60.9 ms                      | 61.5 ms: 1.01x slower        |
+-------------------------+------------------------------+------------------------------+
| Geometric mean          | (ref)                        | 1.01x faster                 |
+-------------------------+------------------------------+------------------------------+

Benchmark hidden because not significant (10): unpack_sequence, float, deepcopy_reduce, json_dumps, comprehensions, deltablue, raytrace, nbody, scimark_fft, richards
```
性能有普遍的提升

